### PR TITLE
feat: Implement Custom Linter

### DIFF
--- a/lib/src/core/di/parts/services.dart
+++ b/lib/src/core/di/parts/services.dart
@@ -8,6 +8,6 @@ CacheService cacheService(Ref ref) {
 }
 
 @riverpod
-RestClient restClient(Ref ref) {
+RestClient restClientService(Ref ref) {
   return RestClient(ref.read(dioProvider));
 }

--- a/packages/flutter_guardian/.gitignore
+++ b/packages/flutter_guardian/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/

--- a/packages/flutter_guardian/.metadata
+++ b/packages/flutter_guardian/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "ea121f8859e4b13e47a8f845e4586164519588bc"
+  channel: "stable"
+
+project_type: package

--- a/packages/flutter_guardian/CHANGELOG.md
+++ b/packages/flutter_guardian/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [1.0.0] - 2024-06-10
+### Added
+- Initial release of flutter_guardian.
+- Provides custom lint rules for Flutter and Dart projects.
+- Enforces repository, service and use case naming conventions.
+- Includes easy integration with analysis_options.yaml.
+
+### Challenges
+- Send `filename` and `pattern` from `analysis_options.yaml`.

--- a/packages/flutter_guardian/LICENSE
+++ b/packages/flutter_guardian/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Momshad Dinury
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flutter_guardian/README.md
+++ b/packages/flutter_guardian/README.md
@@ -1,0 +1,50 @@
+# flutter_guardian
+
+A collection of custom lint rules to help enforce best practices and code consistency in your Flutter and Dart projects.
+
+## Features
+
+- Enforce repository naming conventions
+- Enforce service naming conventions
+- Additional customizable lint rules for your codebase
+
+## Getting Started
+
+Add `flutter_guardian` to your `dev_dependencies` in `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  flutter_guardian:
+    path: packages/flutter_guardian
+```
+
+Then, include the lints in your project's `analysis_options.yaml`:
+
+```yaml
+include: package:flutter_guardian/analysis_options.yaml
+```
+
+## Usage
+
+Once added, your IDE and `dart analyze` will automatically use the custom lint rules provided by flutter_guardian.  
+To run the linter manually:
+
+```sh
+dart analyze
+```
+
+## Example
+
+Suppose you have a repository class named `userRepo.dart`. The linter will flag this as a violation and suggest renaming it to `user_repository.dart` to follow the enforced naming convention.
+
+## Customization
+
+You can extend or override the provided rules by editing your project's `analysis_options.yaml` after the `include` line.
+
+## Contributing
+
+Contributions are welcome! Please open issues or pull requests for new rules, bug fixes, or improvements.
+
+## License
+
+This project is licensed under the MIT License.

--- a/packages/flutter_guardian/analysis_options.yaml
+++ b/packages/flutter_guardian/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/flutter_guardian/lib/flutter_guardian.dart
+++ b/packages/flutter_guardian/lib/flutter_guardian.dart
@@ -1,0 +1,17 @@
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+import 'rules/rules.dart';
+
+// This is the entrypoint of our custom linter
+PluginBase createPlugin() => _FlutterGuardian();
+
+/// A plugin class is used to list all the assists/lints defined by a plugin.
+class _FlutterGuardian extends PluginBase {
+  /// We list all the custom warnings/infos/errors
+  @override
+  List<LintRule> getLintRules(CustomLintConfigs configs) => [
+    RepositoryNamingConvention(configs),
+    UseCaseNamingConvention(configs),
+    ServiceNamingConvention(configs),
+  ];
+}

--- a/packages/flutter_guardian/lib/rules/repository_naming_lint.dart
+++ b/packages/flutter_guardian/lib/rules/repository_naming_lint.dart
@@ -1,0 +1,64 @@
+part of 'rules.dart';
+
+class RepositoryNamingConvention extends DartLintRule {
+  const RepositoryNamingConvention(this.configs) : super(code: _code);
+
+  final CustomLintConfigs configs;
+
+  /// Metadata about the warning that will show-up in the IDE.
+  /// This is used for `// ignore: code` and enabling/disabling the lint
+  static const _code = LintCode(
+    name: 'invalid_repository_name',
+    problemMessage: 'Names in a repository file must include "Repository".',
+    correctionMessage: 'Try renaming to include "Repository"',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  bool _isInRepositoryFile(CustomLintResolver resolver) {
+    return resolver.source.fullName.contains('di/parts/repository.dart');
+  }
+
+  void _checkNameAndReport({
+    required String name,
+    required AstNode node,
+    required ErrorReporter reporter,
+  }) {
+    if (!name.contains('Repository')) {
+      reporter.atNode(node, _code);
+    }
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addVariableDeclaration((node) {
+      if (!_isInRepositoryFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+
+    context.registry.addMethodDeclaration((node) {
+      if (!_isInRepositoryFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+
+    context.registry.addFunctionDeclaration((node) {
+      if (!_isInRepositoryFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+  }
+}

--- a/packages/flutter_guardian/lib/rules/rules.dart
+++ b/packages/flutter_guardian/lib/rules/rules.dart
@@ -1,0 +1,8 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+part 'repository_naming_lint.dart';
+part 'use_case_naming_lint.dart';
+part 'service_naming_lint.dart';

--- a/packages/flutter_guardian/lib/rules/service_naming_lint.dart
+++ b/packages/flutter_guardian/lib/rules/service_naming_lint.dart
@@ -1,0 +1,62 @@
+part of 'rules.dart';
+
+class ServiceNamingConvention extends DartLintRule {
+  const ServiceNamingConvention(this.configs) : super(code: _code);
+
+  final CustomLintConfigs configs;
+
+  static const _code = LintCode(
+    name: 'invalid_service_name',
+    problemMessage: 'Names in a service file must include "Service".',
+    correctionMessage: 'Try renaming to include "Service"',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  bool _isInServiceFile(CustomLintResolver resolver) {
+    return resolver.source.fullName.contains('di/parts/services.dart');
+  }
+
+  void _checkNameAndReport({
+    required String name,
+    required AstNode node,
+    required ErrorReporter reporter,
+  }) {
+    if (!name.contains('Service')) {
+      reporter.atNode(node, _code);
+    }
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addVariableDeclaration((node) {
+      if (!_isInServiceFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+
+    context.registry.addMethodDeclaration((node) {
+      if (!_isInServiceFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+
+    context.registry.addFunctionDeclaration((node) {
+      if (!_isInServiceFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+  }
+}

--- a/packages/flutter_guardian/lib/rules/use_case_naming_lint.dart
+++ b/packages/flutter_guardian/lib/rules/use_case_naming_lint.dart
@@ -1,0 +1,62 @@
+part of 'rules.dart';
+
+class UseCaseNamingConvention extends DartLintRule {
+  const UseCaseNamingConvention(this.configs) : super(code: _code);
+
+  final CustomLintConfigs configs;
+
+  static const _code = LintCode(
+    name: 'invalid_use_case_name',
+    problemMessage: 'Names in a use case file must include "UseCase".',
+    correctionMessage: 'Try renaming to include "UseCase"',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  bool _isInUseCaseFile(CustomLintResolver resolver) {
+    return resolver.source.fullName.contains('di/parts/use_cases.dart');
+  }
+
+  void _checkNameAndReport({
+    required String name,
+    required AstNode node,
+    required ErrorReporter reporter,
+  }) {
+    if (!name.contains('UseCase')) {
+      reporter.atNode(node, _code);
+    }
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addVariableDeclaration((node) {
+      if (!_isInUseCaseFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+
+    context.registry.addMethodDeclaration((node) {
+      if (!_isInUseCaseFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+
+    context.registry.addFunctionDeclaration((node) {
+      if (!_isInUseCaseFile(resolver)) return;
+      _checkNameAndReport(
+        name: node.name.lexeme,
+        node: node,
+        reporter: reporter,
+      );
+    });
+  }
+}

--- a/packages/flutter_guardian/pubspec.yaml
+++ b/packages/flutter_guardian/pubspec.yaml
@@ -1,0 +1,58 @@
+name: flutter_guardian
+description: "Custom linter for Flutter projects."
+version: 0.0.1
+homepage:
+
+environment:
+  sdk: ^3.7.2
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  analyzer:
+  analyzer_plugin:
+  # custom_lint_builder will give us tools for writing lints
+  custom_lint_builder: ^0.7.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+
+  # To add assets to your package, add an assets section, like this:
+  # assets:
+  #   - images/a_dot_burr.jpeg
+  #   - images/a_dot_ham.jpeg
+  #
+  # For details regarding assets in packages, see
+  # https://flutter.dev/to/asset-from-package
+  #
+  # An image asset can refer to one or more resolution-specific "variants", see
+  # https://flutter.dev/to/resolution-aware-images
+
+  # To add custom fonts to your package, add a fonts section here,
+  # in this "flutter" section. Each entry in this list should have a
+  # "family" key with the font family name, and a "fonts" key with a
+  # list giving the asset and other descriptors for the font. For
+  # example:
+  # fonts:
+  #   - family: Schyler
+  #     fonts:
+  #       - asset: fonts/Schyler-Regular.ttf
+  #       - asset: fonts/Schyler-Italic.ttf
+  #         style: italic
+  #   - family: Trajan Pro
+  #     fonts:
+  #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts in packages, see
+  # https://flutter.dev/to/font-from-package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,8 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   build_runner:
   custom_lint:
+  flutter_guardian:
+   path: packages/flutter_guardian/
   riverpod_generator:
   riverpod_lint:
   flutter_gen_runner:


### PR DESCRIPTION
This pull request introduces the initial version of `flutter_guardian`, a package that provides custom lint rules to enforce best practices and improve code consistency in Flutter and Dart projects.

### Features

1. Enforces naming conventions for DI repositories 
2. Enforces naming conventions for DI services
3. Enforces naming conventions for DI use cases

### Usage

To integrate flutter_guardian into a project:

Add the package to dev_dependencies in pubspec.yaml:
```
dev_dependencies:
  flutter_guardian:
    path: packages/flutter_guardian
```

Include the lint rules in `analysis_options.yaml`:

```include: package:flutter_guardian/analysis_options.yaml```

Run the Dart analyzer manually if needed:

```dart analyze```

The linter will automatically pick up and enforce the defined rules through IDE integrations or manual runs.

### Example

if someone tries to declare a method, function or variable inside the `repository.dart` file of `DI` without using the pattern `Repository` it will give an error.

<img width="748" height="331" alt="Screenshot 2025-07-23 at 12 56 53 PM" src="https://github.com/user-attachments/assets/420ae57f-6730-4d3b-bd6b-ed8e1e249eb9" />
