### PR TITLE
chore: Keep repository DI providers alive across app lifecycle (#17)

### DIFF
--- a/lib/src/core/di/parts/repository.dart
+++ b/lib/src/core/di/parts/repository.dart
@@ -1,7 +1,7 @@
 part of '../dependency_injection.dart';
 
 @Riverpod(keepAlive: true)
-AuthenticationRepositoryImpl authenticationRepository(Ref ref) {
+AuthenticationRepository authenticationRepository(Ref ref) {
   return AuthenticationRepositoryImpl(
     remote: ref.read(restClientServiceProvider),
     local: ref.read(cacheServiceProvider),

--- a/lib/src/core/di/parts/repository.dart
+++ b/lib/src/core/di/parts/repository.dart
@@ -1,6 +1,6 @@
 part of '../dependency_injection.dart';
 
-@riverpod
+@Riverpod(keepAlive: true)
 AuthenticationRepositoryImpl authenticationRepository(Ref ref) {
   return AuthenticationRepositoryImpl(
     remote: ref.read(restClientServiceProvider),
@@ -8,12 +8,12 @@ AuthenticationRepositoryImpl authenticationRepository(Ref ref) {
   );
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 RouterRepository routerRepository(Ref ref) {
   return RouterRepositoryImpl(cacheService: ref.read(cacheServiceProvider));
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 LocaleRepository localeRepository(Ref ref) {
   return LocaleRepositoryImpl(ref.read(cacheServiceProvider));
 }


### PR DESCRIPTION
Repositories were previously annotated with @riverpod (auto-dispose), causing their in-memory runtime caches to be lost when no longer listened to. This PR marks them as keep-alive so they persist for the entire app lifecycle.

**Rationale**
Some repositories maintain ephemeral runtime cache/state that must survive temporary absence of listeners. Auto-disposal prevented reuse and forced unnecessary reinitialization. Keeping them alive ensures consistent cached data and fewer cold starts.

Refs #17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved stability: key services now stay active to reduce unexpected logouts, preserve chosen language, and prevent intermittent navigation hiccups during longer sessions.

- Chores
  - Adjusted provider behavior to keep essential app services alive for more consistent behavior and smoother screen transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->