### PR TITLE
chore: Updated build runner command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A comprehensive, scalable foundation for building maintainable Flutter applicati
 
 3. **Generate code**
    ```bash
-   flutter pub run build_runner build --delete-conflicting-outputs
+   dart run build_runner build --delete-conflicting-outputs
    ```
 
 4. **Run the application**
@@ -55,7 +55,7 @@ A comprehensive, scalable foundation for building maintainable Flutter applicati
 
 For continuous code generation during development:
 ```bash
-flutter pub run build_runner watch --delete-conflicting-outputs
+dart run build_runner watch --delete-conflicting-outputs
 ```
 
 ## Architecture Overview
@@ -214,10 +214,10 @@ flutter_template/
 Run code generation after making changes to annotated files:
 ```bash
 # One-time generation
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 
 # Watch mode for development
-flutter pub run build_runner watch --delete-conflicting-outputs
+dart run build_runner watch --delete-conflicting-outputs
 ```
 
 ### Adding New Features


### PR DESCRIPTION
Replace flutter pub run commands with dart run commands in build scripts

### **Summary**
Updated build runner commands to use the modern dart CLI instead of the deprecated flutter pub approach for better compatibility and following current best practices.

**Changes**
- Changed flutter pub run build_runner build --delete-conflicting-outputs to dart run build_runner build --delete-conflicting-outputs

- Changed flutter pub run build_runner watch --delete-conflicting-outputs to dart run build_runner watch --delete-conflicting-outputs


**Rationale**

- The dart run command is the current recommended approach

- These changes ensure compatibility with newer versions of the Dart SDK

- Maintains the same functionality while using modern CLI conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code-generation commands to use Dart’s runner for both build and watch workflows.
  * Revised instructions across Quick Start (Generate code), Development Setup (continuous generation), Architecture Overview (snippet), and Development Guidelines (Code Generation) for consistency.
  * Explicitly notes that the application run step is unchanged.
  * Improves clarity for setting up and running code generation, reducing confusion between command variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->