### PR TITLE
fix (28): Remove EmailValidation from LoginForm

### DIFF
--- a/lib/src/presentation/features/authentication/login/widgets/login_form.dart
+++ b/lib/src/presentation/features/authentication/login/widgets/login_form.dart
@@ -25,10 +25,7 @@ class _LoginFormState extends State<_LoginForm> {
         TextFormField(
           controller: widget.emailController,
           decoration: InputDecoration(hintText: context.locale.email),
-          validator: context.validator.apply([
-            RequiredValidation(),
-            EmailValidation(),
-          ]),
+          validator: context.validator.apply([RequiredValidation()]),
         ),
         const SizedBox(height: 16),
         TextFormField(


### PR DESCRIPTION
Closes #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false rejections in the login form by relaxing email validation. The email field now only requires an entry, improving form completion for users who previously encountered validation blocks.
  * Password requirements remain unchanged (entry required with a minimum length), ensuring continued protection without impacting usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->