### PR TITLE
Refactors typography system and usage

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,12 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		325A064FD689BE8EA7E6F9F6 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA4BD223F9155F81C94FEC92 /* Pods_RunnerTests.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		CFA97F0D068B01EF8D9962C0 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C68D72F3AF47D3CB7D8ECFE6 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,14 +42,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		11227B5A75142B5E4E5AD5D1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		21BA27BE49F1F6221C6071AB /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		562F160028160D526276AD07 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		871048FE56FEE77046E3C86A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +61,10 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9B16E5FAF3133AA69AE9FE19 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		9F9D4766F45734A7C7E2B3F8 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		C68D72F3AF47D3CB7D8ECFE6 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA4BD223F9155F81C94FEC92 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,18 +72,50 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CFA97F0D068B01EF8D9962C0 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E355ED3DAAE4914573A0058A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				325A064FD689BE8EA7E6F9F6 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05BD02B888646CCCECFEA606 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				562F160028160D526276AD07 /* Pods-Runner.debug.xcconfig */,
+				871048FE56FEE77046E3C86A /* Pods-Runner.release.xcconfig */,
+				11227B5A75142B5E4E5AD5D1 /* Pods-Runner.profile.xcconfig */,
+				21BA27BE49F1F6221C6071AB /* Pods-RunnerTests.debug.xcconfig */,
+				9F9D4766F45734A7C7E2B3F8 /* Pods-RunnerTests.release.xcconfig */,
+				9B16E5FAF3133AA69AE9FE19 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		93A26AB28EACF09482823B40 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				C68D72F3AF47D3CB7D8ECFE6 /* Pods_Runner.framework */,
+				FA4BD223F9155F81C94FEC92 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +136,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				05BD02B888646CCCECFEA606 /* Pods */,
+				93A26AB28EACF09482823B40 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				A4FA242B570D436A4AE65498 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				E355ED3DAAE4914573A0058A /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				6C2F04D3382EEAE2D41A7398 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				9E2D5C12F7CC473FE1641460 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -238,6 +286,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		6C2F04D3382EEAE2D41A7398 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +322,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		9E2D5C12F7CC473FE1641460 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A4FA242B570D436A4AE65498 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -379,6 +488,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 21BA27BE49F1F6221C6071AB /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -396,6 +506,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9F9D4766F45734A7C7E2B3F8 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -411,6 +522,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9B16E5FAF3133AA69AE9FE19 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/src/presentation/core/theme/src/part/app_bar_theme.dart
+++ b/lib/src/presentation/core/theme/src/part/app_bar_theme.dart
@@ -4,12 +4,12 @@ class _AppBarLightTheme with ThemeExtensions {
   AppBarTheme call() {
     return AppBarTheme(
       elevation: 1,
+      titleSpacing: 0,
       centerTitle: false,
       backgroundColor: lightColor.appBar.background,
       surfaceTintColor: lightColor.appBar.surfaceTint,
-      titleTextStyle: textStyle.titleMedium.copyWith(
-        color: lightColor.appBar.title,
-        fontWeight: FontWeight.w600,
+      titleTextStyle: textStyle.headingSmall.copyWith(
+        color: lightColor.text.primary,
       ),
       iconTheme: IconThemeData(color: lightColor.appBar.icon),
     );
@@ -20,12 +20,12 @@ class _AppBarDarkTheme with ThemeExtensions {
   AppBarTheme call() {
     return AppBarTheme(
       elevation: 1,
+      titleSpacing: 0,
       centerTitle: false,
       backgroundColor: darkColor.appBar.background,
       surfaceTintColor: darkColor.appBar.surfaceTint,
-      titleTextStyle: textStyle.titleMedium.copyWith(
-        color: darkColor.appBar.title,
-        fontWeight: FontWeight.w600,
+      titleTextStyle: textStyle.headingSmall.copyWith(
+        color: darkColor.text.primary,
       ),
       iconTheme: IconThemeData(color: darkColor.appBar.icon),
     );

--- a/lib/src/presentation/core/theme/src/theme_extensions/src/colors/part/app_bar_colors.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/colors/part/app_bar_colors.dart
@@ -13,13 +13,13 @@ class _LightAppBarColors extends AppBarColors {
   const _LightAppBarColors();
 
   @override
-  Color get background => _Primitive.neutral0;
+  Color get background => _Primitive.neutral10;
 
   @override
   Color get icon => _Primitive.neutral60;
 
   @override
-  Color get surfaceTint => _Primitive.neutral0;
+  Color get surfaceTint => _Primitive.neutral10;
 
   @override
   Color get title => _Primitive.neutral50;

--- a/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
@@ -30,24 +30,6 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
     );
   }
 
-  /// Used for medium-emphasis text that separates content sections.
-  ///
-  /// Title:
-  /// - Large: 20.0–21.0
-  /// - Medium: 18.0–19.0
-  /// - Small: 16.0–17.0
-  /* TextStyle get titleLarge {
-    return const TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
-  } */
-
-  TextStyle get titleMedium {
-    return const TextStyle(fontSize: 18, fontWeight: FontWeight.w500);
-  }
-
-  /* TextStyle get titleSmall {
-    return const TextStyle(fontSize: 16, fontWeight: FontWeight.w500);
-  } */
-
   /// Primary style for most of the readable content.
   ///
   /// Body:
@@ -62,10 +44,6 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
     return const TextStyle(fontSize: 14, fontWeight: FontWeight.w400);
   }
 
-  /* TextStyle get bodySmall {
-    return const TextStyle(fontSize: 12, fontWeight: FontWeight.w400);
-  } */
-
   /// For text on buttons, labels, and other interactive elements.
   ///
   /// Label:
@@ -75,22 +53,6 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
   TextStyle get labelLarge {
     return const TextStyle(fontSize: 14, fontWeight: FontWeight.w500);
   }
-
-  /* TextStyle get labelMedium {
-    return const TextStyle(fontSize: 12, fontWeight: FontWeight.w500);
-  } */
-
-  /* TextStyle get labelSmall {
-    return const TextStyle(fontSize: 10, fontWeight: FontWeight.w500);
-  } */
-
-  /// Used for supplementary text like captions, overlines, or hints.
-  ///
-  /// Caption:
-  /// - 12.0
-  /* TextStyle get caption {
-    return const TextStyle(fontSize: 12, fontWeight: FontWeight.w400);
-  } */
 
   @override
   ThemeExtension<TextStyleExtension> copyWith() => const TextStyleExtension();

--- a/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
@@ -8,7 +8,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.33,
       fontSize: 24,
       letterSpacing: 0,
-      fontWeight: FontWeight.w600,
+      fontWeight: .w600,
     );
   }
 
@@ -17,7 +17,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.40,
       fontSize: 20,
       letterSpacing: 0,
-      fontWeight: FontWeight.w600,
+      fontWeight: .w600,
     );
   }
 
@@ -26,7 +26,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.33,
       fontSize: 18,
       letterSpacing: 0,
-      fontWeight: FontWeight.w500,
+      fontWeight: .w500,
     );
   }
 
@@ -35,7 +35,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.50,
       fontSize: 16,
       letterSpacing: 0,
-      fontWeight: FontWeight.w400,
+      fontWeight: .w400,
     );
   }
 
@@ -44,7 +44,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.42,
       fontSize: 14,
       letterSpacing: 0,
-      fontWeight: FontWeight.w400,
+      fontWeight: .w400,
     );
   }
 
@@ -53,7 +53,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.15,
       fontSize: 14,
       letterSpacing: 1,
-      fontWeight: FontWeight.w500,
+      fontWeight: .w500,
     );
   }
 

--- a/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
@@ -5,8 +5,8 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
 
   TextStyle get headingLarge {
     return const TextStyle(
-      fontSize: 24,
       height: 1.33,
+      fontSize: 24,
       letterSpacing: 0,
       fontWeight: FontWeight.w600,
     );
@@ -14,8 +14,8 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
 
   TextStyle get headingMedium {
     return const TextStyle(
-      fontSize: 20,
       height: 1.40,
+      fontSize: 20,
       letterSpacing: 0,
       fontWeight: FontWeight.w600,
     );
@@ -30,18 +30,22 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
     );
   }
 
-  /// Primary style for most of the readable content.
-  ///
-  /// Body:
-  /// - Large: 16.0–17.0
-  /// - Medium: 14.0–15.0
-  /// - Small: 12.0–13.0
   TextStyle get bodyLarge {
-    return const TextStyle(fontSize: 16, fontWeight: FontWeight.w400);
+    return const TextStyle(
+      height: 1.50,
+      fontSize: 16,
+      letterSpacing: 0,
+      fontWeight: FontWeight.w400,
+    );
   }
 
   TextStyle get bodyMedium {
-    return const TextStyle(fontSize: 14, fontWeight: FontWeight.w400);
+    return const TextStyle(
+      height: 1.42,
+      fontSize: 14,
+      letterSpacing: 0,
+      fontWeight: FontWeight.w400,
+    );
   }
 
   /// For text on buttons, labels, and other interactive elements.

--- a/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
@@ -48,14 +48,13 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
     );
   }
 
-  /// For text on buttons, labels, and other interactive elements.
-  ///
-  /// Label:
-  /// - Large: 14.0–15.0
-  /// - Medium: 12.0–13.0
-  /// - Small: 10.0–11.0
-  TextStyle get labelLarge {
-    return const TextStyle(fontSize: 14, fontWeight: FontWeight.w500);
+  TextStyle get labelMedium {
+    return const TextStyle(
+      height: 1.15,
+      fontSize: 14,
+      letterSpacing: 1,
+      fontWeight: FontWeight.w500,
+    );
   }
 
   @override

--- a/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
@@ -3,22 +3,31 @@ import 'package:flutter/material.dart';
 class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
   const TextStyleExtension();
 
-  /// Ideal for page titles, section headings, or content that needs emphasis.
-  ///
-  /// Headline:
-  /// - Large: 30.0–33.0
-  /// - Medium: 26.0–29.0
-  /// - Small: 22.0–25.0
-  TextStyle get headlineLarge {
-    return const TextStyle(fontSize: 30, fontWeight: FontWeight.w600);
+  TextStyle get headingLarge {
+    return const TextStyle(
+      fontSize: 24,
+      height: 1.33,
+      letterSpacing: 0,
+      fontWeight: FontWeight.w600,
+    );
   }
 
-  TextStyle get headlineMedium {
-    return const TextStyle(fontSize: 26, fontWeight: FontWeight.w600);
+  TextStyle get headingMedium {
+    return const TextStyle(
+      fontSize: 20,
+      height: 1.40,
+      letterSpacing: 0,
+      fontWeight: FontWeight.w600,
+    );
   }
 
-  TextStyle get headlineSmall {
-    return const TextStyle(fontSize: 22, fontWeight: FontWeight.w600);
+  TextStyle get headingSmall {
+    return const TextStyle(
+      height: 1.33,
+      fontSize: 18,
+      letterSpacing: 0,
+      fontWeight: FontWeight.w500,
+    );
   }
 
   /// Used for medium-emphasis text that separates content sections.
@@ -27,17 +36,17 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
   /// - Large: 20.0–21.0
   /// - Medium: 18.0–19.0
   /// - Small: 16.0–17.0
-  TextStyle get titleLarge {
+  /* TextStyle get titleLarge {
     return const TextStyle(fontSize: 20, fontWeight: FontWeight.w500);
-  }
+  } */
 
   TextStyle get titleMedium {
     return const TextStyle(fontSize: 18, fontWeight: FontWeight.w500);
   }
 
-  TextStyle get titleSmall {
+  /* TextStyle get titleSmall {
     return const TextStyle(fontSize: 16, fontWeight: FontWeight.w500);
-  }
+  } */
 
   /// Primary style for most of the readable content.
   ///
@@ -53,9 +62,9 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
     return const TextStyle(fontSize: 14, fontWeight: FontWeight.w400);
   }
 
-  TextStyle get bodySmall {
+  /* TextStyle get bodySmall {
     return const TextStyle(fontSize: 12, fontWeight: FontWeight.w400);
-  }
+  } */
 
   /// For text on buttons, labels, and other interactive elements.
   ///
@@ -67,21 +76,21 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
     return const TextStyle(fontSize: 14, fontWeight: FontWeight.w500);
   }
 
-  TextStyle get labelMedium {
+  /* TextStyle get labelMedium {
     return const TextStyle(fontSize: 12, fontWeight: FontWeight.w500);
-  }
+  } */
 
-  TextStyle get labelSmall {
+  /* TextStyle get labelSmall {
     return const TextStyle(fontSize: 10, fontWeight: FontWeight.w500);
-  }
+  } */
 
   /// Used for supplementary text like captions, overlines, or hints.
   ///
   /// Caption:
   /// - 12.0
-  TextStyle get caption {
+  /* TextStyle get caption {
     return const TextStyle(fontSize: 12, fontWeight: FontWeight.w400);
-  }
+  } */
 
   @override
   ThemeExtension<TextStyleExtension> copyWith() => const TextStyleExtension();

--- a/lib/src/presentation/core/widgets/link_text.dart
+++ b/lib/src/presentation/core/widgets/link_text.dart
@@ -20,17 +20,16 @@ class LinkText extends StatelessWidget {
       alignment: Alignment.center,
       child: TextButton(
         onPressed: onTap,
-        child: RichText(
-          textAlign: TextAlign.center,
-          text: TextSpan(
+        child: Text.rich(
+          TextSpan(
             text: text,
-            style: context.textStyle.labelLarge.copyWith(
+            style: context.textStyle.labelMedium.copyWith(
               color: context.color.text.secondary,
             ),
             children: [
               TextSpan(
                 text: linkText,
-                style: context.textStyle.labelLarge.copyWith(
+                style: context.textStyle.labelMedium.copyWith(
                   color: context.color.text.primary,
                 ),
               ),

--- a/lib/src/presentation/core/widgets/navigation_shell.dart
+++ b/lib/src/presentation/core/widgets/navigation_shell.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/extensions/app_localization.dart';
 import '../theme/theme.dart';
+import 'text/typography.dart';
 
 class NavigationShell extends StatefulWidget {
   const NavigationShell({super.key, required this.statefulNavigationShell});
@@ -18,7 +19,7 @@ class _NavigationShellState extends State<NavigationShell> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Flutter Template'),
+        title: const HeadingSmallText('Flutter Template'),
         titleSpacing: context.spacing.s16,
       ),
       body: widget.statefulNavigationShell,

--- a/lib/src/presentation/core/widgets/navigation_shell.dart
+++ b/lib/src/presentation/core/widgets/navigation_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/extensions/app_localization.dart';
+import '../theme/theme.dart';
 
 class NavigationShell extends StatefulWidget {
   const NavigationShell({super.key, required this.statefulNavigationShell});
@@ -16,7 +17,10 @@ class _NavigationShellState extends State<NavigationShell> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Flutter Template')),
+      appBar: AppBar(
+        title: const Text('Flutter Template'),
+        titleSpacing: context.spacing.s16,
+      ),
       body: widget.statefulNavigationShell,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: widget.statefulNavigationShell.currentIndex,

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -19,3 +19,21 @@ class HeadingLarge extends StatelessWidget {
     );
   }
 }
+
+class HeadingSmall extends StatelessWidget {
+  const HeadingSmall(this.text, {super.key, this.textAlign});
+
+  final String text;
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      style: context.textStyle.headingSmall.copyWith(
+        color: context.color.text.primary,
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -44,31 +44,35 @@ class HeadingSmallText extends _Typography {
   }
 }
 
+enum _BodyMediumTextVariant { primary, secondary }
+
 class BodyMediumText extends _Typography {
-  const BodyMediumText(super.text, {super.key, super.textAlign});
+  const BodyMediumText(super.text, {super.key, super.textAlign})
+    : _variant = _BodyMediumTextVariant.primary;
+
+  const BodyMediumText.secondary(super.text, {super.key, super.textAlign})
+    : _variant = _BodyMediumTextVariant.secondary;
+
+  final _BodyMediumTextVariant _variant;
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      text,
-      textAlign: textAlign,
-      style: context.textStyle.bodyMedium,
+    final defaultStyle = context.textStyle.bodyMedium.copyWith(
+      color: context.color.text.primary,
     );
-  }
-}
 
-class SecondaryBodyMediumText extends _Typography {
-  const SecondaryBodyMediumText(super.text, {super.key, super.textAlign});
+    final secondaryStyle = context.textStyle.bodyMedium.copyWith(
+      color: context.color.text.secondary,
+      fontWeight: .w500,
+    );
 
-  @override
-  Widget build(BuildContext context) {
     return Text(
       text,
       textAlign: textAlign,
-      style: context.textStyle.bodyMedium.copyWith(
-        color: context.color.text.secondary,
-        fontWeight: FontWeight.w500,
-      ),
+      style: switch (_variant) {
+        _BodyMediumTextVariant.primary => defaultStyle,
+        _BodyMediumTextVariant.secondary => secondaryStyle,
+      },
     );
   }
 }

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -3,25 +3,51 @@ import 'package:flutter/material.dart';
 import '../../theme/theme.dart';
 
 abstract class _Typography extends StatelessWidget {
-  const _Typography(this.text, {super.key, this.textAlign});
+  const _Typography(
+    this.text, {
+    super.key,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.softWrap,
+    this.textDirection,
+    this.semanticsLabel,
+  });
 
   final String text;
   final TextAlign? textAlign;
+  final int? maxLines;
+  final TextOverflow? overflow;
+  final bool? softWrap;
+  final TextDirection? textDirection;
+  final String? semanticsLabel;
 
   @override
-  Widget build(BuildContext context) {
-    throw UnimplementedError();
-  }
+  Widget build(BuildContext context);
 }
 
 class HeadingLargeText extends _Typography {
-  const HeadingLargeText(super.text, {super.key, super.textAlign});
+  const HeadingLargeText(
+    super.text, {
+    super.key,
+    super.textAlign,
+    super.maxLines,
+    super.overflow,
+    super.softWrap,
+    super.textDirection,
+    super.semanticsLabel,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Text(
       text,
       textAlign: textAlign,
+      maxLines: maxLines,
+      overflow: overflow,
+      softWrap: softWrap,
+      textDirection: textDirection,
+      semanticsLabel: semanticsLabel,
       style: context.textStyle.headingLarge.copyWith(
         color: context.color.text.primary,
       ),
@@ -30,13 +56,27 @@ class HeadingLargeText extends _Typography {
 }
 
 class HeadingSmallText extends _Typography {
-  const HeadingSmallText(super.text, {super.key, super.textAlign});
+  const HeadingSmallText(
+    super.text, {
+    super.key,
+    super.textAlign,
+    super.maxLines,
+    super.overflow,
+    super.softWrap,
+    super.textDirection,
+    super.semanticsLabel,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Text(
       text,
       textAlign: textAlign,
+      maxLines: maxLines,
+      overflow: overflow,
+      softWrap: softWrap,
+      textDirection: textDirection,
+      semanticsLabel: semanticsLabel,
       style: context.textStyle.headingSmall.copyWith(
         color: context.color.text.primary,
       ),
@@ -47,32 +87,49 @@ class HeadingSmallText extends _Typography {
 enum _BodyMediumTextVariant { primary, secondary }
 
 class BodyMediumText extends _Typography {
-  const BodyMediumText(super.text, {super.key, super.textAlign})
-    : _variant = _BodyMediumTextVariant.primary;
+  const BodyMediumText(
+    super.text, {
+    super.key,
+    super.textAlign,
+    super.maxLines,
+    super.overflow,
+    super.softWrap,
+    super.textDirection,
+    super.semanticsLabel,
+  }) : _variant = _BodyMediumTextVariant.primary;
 
-  const BodyMediumText.secondary(super.text, {super.key, super.textAlign})
-    : _variant = _BodyMediumTextVariant.secondary;
+  const BodyMediumText.secondary(
+    super.text, {
+    super.key,
+    super.textAlign,
+    super.maxLines,
+    super.overflow,
+    super.softWrap,
+    super.textDirection,
+    super.semanticsLabel,
+  }) : _variant = _BodyMediumTextVariant.secondary;
 
   final _BodyMediumTextVariant _variant;
 
   @override
   Widget build(BuildContext context) {
-    final defaultStyle = context.textStyle.bodyMedium.copyWith(
-      color: context.color.text.primary,
-    );
-
-    final secondaryStyle = context.textStyle.bodyMedium.copyWith(
-      color: context.color.text.secondary,
-      fontWeight: .w500,
-    );
+    final style = switch (_variant) {
+      .primary => context.textStyle.bodyMedium,
+      .secondary => context.textStyle.bodyMedium.copyWith(
+        color: context.color.text.secondary,
+        fontWeight: .w500,
+      ),
+    };
 
     return Text(
       text,
       textAlign: textAlign,
-      style: switch (_variant) {
-        _BodyMediumTextVariant.primary => defaultStyle,
-        _BodyMediumTextVariant.secondary => secondaryStyle,
-      },
+      maxLines: maxLines,
+      overflow: overflow,
+      softWrap: softWrap,
+      textDirection: textDirection,
+      semanticsLabel: semanticsLabel,
+      style: style,
     );
   }
 }

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -2,11 +2,20 @@ import 'package:flutter/material.dart';
 
 import '../../theme/theme.dart';
 
-class HeadingLarge extends StatelessWidget {
-  const HeadingLarge(this.text, {super.key, this.textAlign});
+abstract class _Typography extends StatelessWidget {
+  const _Typography(this.text, {super.key, this.textAlign});
 
   final String text;
   final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    throw UnimplementedError();
+  }
+}
+
+class HeadingLarge extends _Typography {
+  const HeadingLarge(super.text, {super.key, super.textAlign});
 
   @override
   Widget build(BuildContext context) {
@@ -20,11 +29,8 @@ class HeadingLarge extends StatelessWidget {
   }
 }
 
-class HeadingSmall extends StatelessWidget {
-  const HeadingSmall(this.text, {super.key, this.textAlign});
-
-  final String text;
-  final TextAlign? textAlign;
+class HeadingSmall extends _Typography {
+  const HeadingSmall(super.text, {super.key, super.textAlign});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/theme.dart';
+
+class HeadingLarge extends StatelessWidget {
+  const HeadingLarge(this.text, {super.key, this.textAlign});
+
+  final String text;
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      style: context.textStyle.headingLarge.copyWith(
+        color: context.color.text.primary,
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -14,8 +14,8 @@ abstract class _Typography extends StatelessWidget {
   }
 }
 
-class HeadingLarge extends _Typography {
-  const HeadingLarge(super.text, {super.key, super.textAlign});
+class HeadingLargeText extends _Typography {
+  const HeadingLargeText(super.text, {super.key, super.textAlign});
 
   @override
   Widget build(BuildContext context) {
@@ -29,8 +29,8 @@ class HeadingLarge extends _Typography {
   }
 }
 
-class HeadingSmall extends _Typography {
-  const HeadingSmall(super.text, {super.key, super.textAlign});
+class HeadingSmallText extends _Typography {
+  const HeadingSmallText(super.text, {super.key, super.textAlign});
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +39,35 @@ class HeadingSmall extends _Typography {
       textAlign: textAlign,
       style: context.textStyle.headingSmall.copyWith(
         color: context.color.text.primary,
+      ),
+    );
+  }
+}
+
+class BodyMediumText extends _Typography {
+  const BodyMediumText(super.text, {super.key, super.textAlign});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      style: context.textStyle.bodyMedium,
+    );
+  }
+}
+
+class SecondaryBodyMediumText extends _Typography {
+  const SecondaryBodyMediumText(super.text, {super.key, super.textAlign});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      textAlign: textAlign,
+      style: context.textStyle.bodyMedium.copyWith(
+        color: context.color.text.secondary,
+        fontWeight: FontWeight.w500,
       ),
     );
   }

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../../core/extensions/app_localization.dart';
 import '../../../../core/router/routes.dart';
 import '../../../../core/theme/theme.dart';
-import '../../../../core/widgets/text/typography.dart' hide Typography123;
+import '../../../../core/widgets/text/typography.dart';
 
 class CreateNewPasswordPage extends StatelessWidget {
   const CreateNewPasswordPage({super.key});

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../../core/extensions/app_localization.dart';
 import '../../../../core/router/routes.dart';
 import '../../../../core/theme/theme.dart';
+import '../../../../core/widgets/text/typography.dart';
 
 class CreateNewPasswordPage extends StatelessWidget {
   const CreateNewPasswordPage({super.key});
@@ -20,10 +21,7 @@ class CreateNewPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s16),
-              Text(
-                context.locale.createNewPassword,
-                style: context.textStyle.headlineSmall.copyWith(fontSize: 24),
-              ),
+              HeadingLarge(context.locale.createNewPassword),
               Gap(context.spacing.s4),
               Text(
                 context.locale.createNewPasswordHint,

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -21,7 +21,7 @@ class CreateNewPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s16),
-              SecondaryBodyMediumText(context.locale.createNewPasswordHint),
+              BodyMediumText.secondary(context.locale.createNewPasswordHint),
               Gap(context.spacing.s16),
               const _Form(),
               Gap(context.spacing.s32),

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -13,7 +13,7 @@ class CreateNewPasswordPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(title: HeadingSmall(context.locale.createNewPassword)),
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: context.padding.p16),
@@ -21,8 +21,6 @@ class CreateNewPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s16),
-              HeadingLarge(context.locale.createNewPassword),
-              Gap(context.spacing.s4),
               Text(
                 context.locale.createNewPasswordHint,
                 style: context.textStyle.bodyMedium.copyWith(
@@ -30,7 +28,7 @@ class CreateNewPasswordPage extends StatelessWidget {
                   color: context.color.text.secondary,
                 ),
               ),
-              Gap(context.spacing.s32),
+              Gap(context.spacing.s16),
               const _Form(),
               Gap(context.spacing.s32),
               FilledButton(

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -13,7 +13,7 @@ class CreateNewPasswordPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: HeadingSmall(context.locale.createNewPassword)),
+      appBar: AppBar(title: HeadingSmallText(context.locale.createNewPassword)),
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: context.padding.p16),
@@ -21,13 +21,7 @@ class CreateNewPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s16),
-              Text(
-                context.locale.createNewPasswordHint,
-                style: context.textStyle.bodyMedium.copyWith(
-                  fontWeight: FontWeight.w500,
-                  color: context.color.text.secondary,
-                ),
-              ),
+              SecondaryBodyMediumText(context.locale.createNewPasswordHint),
               Gap(context.spacing.s16),
               const _Form(),
               Gap(context.spacing.s32),

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../../core/extensions/app_localization.dart';
 import '../../../../core/router/routes.dart';
 import '../../../../core/theme/theme.dart';
-import '../../../../core/widgets/text/typography.dart';
+import '../../../../core/widgets/text/typography.dart' hide Typography123;
 
 class CreateNewPasswordPage extends StatelessWidget {
   const CreateNewPasswordPage({super.key});

--- a/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
@@ -14,7 +14,7 @@ class EmailVerificationPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.locale.checkYourMail)),
+      appBar: AppBar(title: HeadingSmallText(context.locale.checkYourMail)),
       body: SafeArea(
         child: SingleChildScrollView(
           child: Padding(

--- a/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
@@ -6,6 +6,7 @@ import '../../../../../core/extensions/app_localization.dart';
 import '../../../../core/router/routes.dart';
 import '../../../../core/theme/theme.dart';
 import '../../../../core/widgets/link_text.dart';
+import '../../../../core/widgets/text/typography.dart';
 
 class EmailVerificationPage extends StatelessWidget {
   const EmailVerificationPage({super.key});
@@ -23,10 +24,7 @@ class EmailVerificationPage extends StatelessWidget {
                 Gap(context.spacing.s24),
                 FlutterLogo(size: context.spacing.s200),
                 Gap(context.spacing.s24),
-                Text(
-                  context.locale.checkYourMail,
-                  style: context.textStyle.headlineSmall.copyWith(fontSize: 24),
-                ),
+                HeadingLarge(context.locale.checkYourMail),
                 Gap(context.spacing.s8),
                 Text(
                   context.locale.enterVerificationCode,

--- a/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
@@ -26,7 +26,7 @@ class EmailVerificationPage extends StatelessWidget {
                 Gap(context.spacing.s24),
                 HeadingLargeText(context.locale.checkYourMail),
                 Gap(context.spacing.s8),
-                SecondaryBodyMediumText(
+                BodyMediumText.secondary(
                   context.locale.enterVerificationCode,
                   textAlign: TextAlign.center,
                 ),

--- a/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
@@ -24,15 +24,11 @@ class EmailVerificationPage extends StatelessWidget {
                 Gap(context.spacing.s24),
                 FlutterLogo(size: context.spacing.s200),
                 Gap(context.spacing.s24),
-                HeadingLarge(context.locale.checkYourMail),
+                HeadingLargeText(context.locale.checkYourMail),
                 Gap(context.spacing.s8),
-                Text(
+                SecondaryBodyMediumText(
                   context.locale.enterVerificationCode,
                   textAlign: TextAlign.center,
-                  style: context.textStyle.bodyMedium.copyWith(
-                    fontWeight: FontWeight.w500,
-                    color: context.color.text.secondary,
-                  ),
                 ),
                 Gap(context.spacing.s32),
                 const _OTPField(),

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
@@ -13,7 +13,7 @@ class ResetPasswordPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: HeadingSmall(context.locale.resetPassword)),
+      appBar: AppBar(title: HeadingSmallText(context.locale.resetPassword)),
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: context.padding.p16),
@@ -21,17 +21,9 @@ class ResetPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s16),
-              Text(
-                context.locale.enterAssociatedEmail,
-                style: context.textStyle.bodyMedium.copyWith(
-                  color: context.color.text.secondary,
-                ),
-              ),
+              SecondaryBodyMediumText(context.locale.enterAssociatedEmail),
               Gap(context.spacing.s16),
-              Text(
-                context.locale.emailAddress,
-                style: context.textStyle.bodyMedium,
-              ),
+              BodyMediumText(context.locale.emailAddress),
               Gap(context.spacing.s8),
               TextFormField(
                 decoration: InputDecoration(hintText: context.locale.email),

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
@@ -13,16 +13,14 @@ class ResetPasswordPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(title: HeadingSmall(context.locale.resetPassword)),
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsets.symmetric(horizontal: context.padding.p16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Gap(context.spacing.s24),
-              HeadingLarge(context.locale.resetPassword),
-              Gap(context.spacing.s4),
+              Gap(context.spacing.s16),
               Text(
                 context.locale.enterAssociatedEmail,
                 style: context.textStyle.bodyMedium.copyWith(

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
@@ -21,7 +21,7 @@ class ResetPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s16),
-              SecondaryBodyMediumText(context.locale.enterAssociatedEmail),
+              BodyMediumText.secondary(context.locale.enterAssociatedEmail),
               Gap(context.spacing.s16),
               BodyMediumText(context.locale.emailAddress),
               Gap(context.spacing.s8),

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../../core/extensions/app_localization.dart';
 import '../../../../core/router/routes.dart';
 import '../../../../core/theme/theme.dart';
+import '../../../../core/widgets/text/typography.dart';
 
 class ResetPasswordPage extends StatelessWidget {
   const ResetPasswordPage({super.key});
@@ -20,13 +21,7 @@ class ResetPasswordPage extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Gap(context.spacing.s24),
-              Text(
-                context.locale.resetPassword,
-                style: context.textStyle.headlineSmall.copyWith(
-                  fontSize: 24,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
+              HeadingLarge(context.locale.resetPassword),
               Gap(context.spacing.s4),
               Text(
                 context.locale.enterAssociatedEmail,

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_success_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_success_page.dart
@@ -34,18 +34,14 @@ class ResetPasswordSuccessPage extends StatelessWidget {
                   ),
                 ),
                 Gap(context.spacing.s24),
-                HeadingLarge(
+                HeadingLargeText(
                   context.locale.passwordChangeSuccess,
                   textAlign: TextAlign.center,
                 ),
                 Gap(context.spacing.s8),
-                Text(
+                SecondaryBodyMediumText(
                   context.locale.yourPasswordChanged,
                   textAlign: TextAlign.center,
-                  style: context.textStyle.bodyMedium.copyWith(
-                    fontWeight: FontWeight.w500,
-                    color: context.color.text.secondary,
-                  ),
                 ),
                 Gap(context.spacing.s32),
                 FilledButton(

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_success_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_success_page.dart
@@ -39,7 +39,7 @@ class ResetPasswordSuccessPage extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
                 Gap(context.spacing.s8),
-                SecondaryBodyMediumText(
+                BodyMediumText.secondary(
                   context.locale.yourPasswordChanged,
                   textAlign: TextAlign.center,
                 ),

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_success_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_success_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../../core/extensions/app_localization.dart';
 import '../../../../core/theme/theme.dart';
+import '../../../../core/widgets/text/typography.dart';
 
 class ResetPasswordSuccessPage extends StatelessWidget {
   const ResetPasswordSuccessPage({super.key});
@@ -33,10 +34,9 @@ class ResetPasswordSuccessPage extends StatelessWidget {
                   ),
                 ),
                 Gap(context.spacing.s24),
-                Text(
+                HeadingLarge(
                   context.locale.passwordChangeSuccess,
                   textAlign: TextAlign.center,
-                  style: context.textStyle.headlineSmall.copyWith(fontSize: 24),
                 ),
                 Gap(context.spacing.s8),
                 Text(

--- a/lib/src/presentation/features/authentication/login/widgets/language_switcher.dart
+++ b/lib/src/presentation/features/authentication/login/widgets/language_switcher.dart
@@ -6,6 +6,7 @@ import '../../../../../core/extensions/app_localization.dart';
 import '../../../../../core/gen/l10n/app_localizations.dart';
 import '../../../../core/application_state/localization_provider/localization_provider.dart';
 import '../../../../core/theme/theme.dart';
+import '../../../../core/widgets/text/typography.dart';
 
 class LanguageSwitcherWidget extends ConsumerWidget {
   const LanguageSwitcherWidget({super.key});
@@ -21,10 +22,7 @@ class LanguageSwitcherWidget extends ConsumerWidget {
         children: [
           Icon(Icons.language, color: context.color.primary),
           Gap(context.spacing.s4),
-          Text(
-            context.locale.getLanguageName(state.languageCode),
-            style: context.textStyle.bodyMedium,
-          ),
+          BodyMediumText(context.locale.getLanguageName(state.languageCode)),
           const Icon(Icons.arrow_drop_down),
         ],
       ),

--- a/lib/src/presentation/features/authentication/registration/view/registration_page.dart
+++ b/lib/src/presentation/features/authentication/registration/view/registration_page.dart
@@ -6,6 +6,7 @@ import '../../../../../core/extensions/go_router_extension.dart';
 import '../../../../core/router/routes.dart';
 import '../../../../core/theme/theme.dart';
 import '../../../../core/widgets/link_text.dart';
+import '../../../../core/widgets/text/typography.dart';
 
 class RegistrationPage extends StatefulWidget {
   const RegistrationPage({super.key});
@@ -18,7 +19,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(context.locale.signUp)),
+      appBar: AppBar(title: HeadingSmallText(context.locale.signUp)),
       body: SingleChildScrollView(
         padding: EdgeInsets.symmetric(horizontal: context.padding.p16),
         child: Column(

--- a/lib/src/presentation/features/onboarding/view/onboarding_page.dart
+++ b/lib/src/presentation/features/onboarding/view/onboarding_page.dart
@@ -61,7 +61,7 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage>
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            HeadingLarge(
+                            HeadingLargeText(
                               item.title,
                               textAlign: TextAlign.center,
                             ),
@@ -141,7 +141,7 @@ class _OnboardingListItem extends StatelessWidget {
             child: Baseline(
               baseline: context.spacing.s8,
               baselineType: TextBaseline.alphabetic,
-              child: Text(title, style: context.textStyle.bodyMedium),
+              child: BodyMediumText(title),
             ),
           ),
         ],

--- a/lib/src/presentation/features/onboarding/view/onboarding_page.dart
+++ b/lib/src/presentation/features/onboarding/view/onboarding_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/extensions/app_localization.dart';
 import '../../../core/router/routes.dart';
 import '../../../core/theme/theme.dart';
+import '../../../core/widgets/text/typography.dart';
 
 part '../model/onboarding_model.dart';
 
@@ -60,12 +61,9 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage>
                         child: Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            Text(
+                            HeadingLarge(
                               item.title,
                               textAlign: TextAlign.center,
-                              style: context.textStyle.headlineSmall.copyWith(
-                                fontWeight: FontWeight.w500,
-                              ),
                             ),
                             Gap(context.spacing.s24),
                             item.image,


### PR DESCRIPTION
Refactors the text style system by consolidating typography widgets, removing unused text styles, and unifying app bar text style.

- Completes migration of text style system.
- Migrates `bodyMedium` ad-hoc styling to `BodyMediumText` and `SecondaryBodyMediumText`.
- Consolidates typography widgets with an abstract base class.
- Adds `HeadingSmall` widget to unify app bar text style and updates necessary usages.
- Migrates ad-hoc text styling `headlineSmall` to unified `HeadingLarge` typography widget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typography system with reusable heading and body text components used across the app.

* **Style**
  * Updated app bar title spacing and light-theme app bar background/tint for improved visual consistency.
  * Standardized headings and body text across authentication, onboarding, navigation, and other screens by replacing raw Text usage with typography widgets.

* **UX**
  * Improved link and language label text styling for clearer readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->