### PR TITLE
refactor: Allow nullable data on result class

### DIFF
--- a/lib/src/core/base/repository.dart
+++ b/lib/src/core/base/repository.dart
@@ -34,7 +34,7 @@ abstract base class Repository<T> {
   ) async {
     try {
       final result = await operation();
-      return Success(result);
+      return Success(data: result);
     } on Exception catch (e, stackTrace) {
       Log.error(e.toString());
       Log.error(stackTrace.toString());
@@ -70,7 +70,7 @@ abstract base class Repository<T> {
   Result<T, Failure> guard(T Function() operation) {
     try {
       final result = operation();
-      return Success(result);
+      return Success(data: result);
     } on Exception catch (e) {
       return Error(Failure.mapExceptionToFailure(e));
     }

--- a/lib/src/core/base/result.dart
+++ b/lib/src/core/base/result.dart
@@ -4,6 +4,6 @@ part 'result.freezed.dart';
 
 @freezed
 class Result<T, E> with _$Result<T, E> {
-  const factory Result.success(T data) = Success;
+  const factory Result.success({T? data}) = Success;
   const factory Result.error(E error) = Error;
 }

--- a/lib/src/domain/use_cases/authentication_use_case.dart
+++ b/lib/src/domain/use_cases/authentication_use_case.dart
@@ -32,7 +32,7 @@ final class LoginUseCase {
     final result = await repository.login(request);
 
     return switch (result) {
-      Success(:final data) => Success(data),
+      Success(:final data) => Success(data: data),
       Error(:final error) => Error(error.message),
       _ => const Error('Something went wrong'),
     };


### PR DESCRIPTION
This PR updates the Result class to require the data parameter to be passed as a named value. 

**Changes**

* In `result.dart`, `Result.success` now uses a named parameter for `data`
* All usages of `Result.success` in `repository.dart` and `authentication_use_case.dart` were updated to the new format (for example: `Success(data: result)` and `Success(data: data)`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal result handling patterns across the application for improved code consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->