### PR TITLE
Fix build runner error by downgrading retrofit and fixing invalid syntax

### DIFF
--- a/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
+++ b/lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart
@@ -8,7 +8,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.33,
       fontSize: 24,
       letterSpacing: 0,
-      fontWeight: .w600,
+      fontWeight: FontWeight.w600,
     );
   }
 
@@ -17,7 +17,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.40,
       fontSize: 20,
       letterSpacing: 0,
-      fontWeight: .w600,
+      fontWeight: FontWeight.w600,
     );
   }
 
@@ -26,7 +26,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.33,
       fontSize: 18,
       letterSpacing: 0,
-      fontWeight: .w500,
+      fontWeight: FontWeight.w500,
     );
   }
 
@@ -35,7 +35,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.50,
       fontSize: 16,
       letterSpacing: 0,
-      fontWeight: .w400,
+      fontWeight: FontWeight.w400,
     );
   }
 
@@ -44,7 +44,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.42,
       fontSize: 14,
       letterSpacing: 0,
-      fontWeight: .w400,
+      fontWeight: FontWeight.w400,
     );
   }
 
@@ -53,7 +53,7 @@ class TextStyleExtension extends ThemeExtension<TextStyleExtension> {
       height: 1.15,
       fontSize: 14,
       letterSpacing: 1,
-      fontWeight: .w500,
+      fontWeight: FontWeight.w500,
     );
   }
 

--- a/lib/src/presentation/core/widgets/text/typography.dart
+++ b/lib/src/presentation/core/widgets/text/typography.dart
@@ -114,10 +114,10 @@ class BodyMediumText extends _Typography {
   @override
   Widget build(BuildContext context) {
     final style = switch (_variant) {
-      .primary => context.textStyle.bodyMedium,
-      .secondary => context.textStyle.bodyMedium.copyWith(
+      _BodyMediumTextVariant.primary => context.textStyle.bodyMedium,
+      _BodyMediumTextVariant.secondary => context.textStyle.bodyMedium.copyWith(
         color: context.color.text.secondary,
-        fontWeight: .w500,
+        fontWeight: FontWeight.w500,
       ),
     };
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   # Serialization & Deserialization
   dart_mappable:
   # Networking
-  retrofit: ^4.4.0
+  retrofit: '>=4.4.0 <4.8.0'
   dio: ^5.8.0+1
   # Localization
   flutter_localizations:


### PR DESCRIPTION
Downgraded `retrofit` to `<4.8.0` to resolve incompatibility with `retrofit_generator 9.7.0` (missing `Parser.DartMappable` in switch statement).
Also fixed invalid dot-shorthands (e.g., `.w600` instead of `FontWeight.w600`) in `lib/src/presentation/core/theme/src/theme_extensions/src/text_style.dart` and `lib/src/presentation/core/widgets/text/typography.dart` which were flagged by the `analyzer` (version 7.6.0) brought in by dependency constraints.
Verified build succeeds with `dart run build_runner build --delete-conflicting-outputs`.

---
*PR created automatically by Jules for task [8904984681960646903](https://jules.google.com/task/8904984681960646903) started by @momshaddinury*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized code formatting for improved consistency and maintainability.

* **Chores**
  * Updated retrofit dependency constraints for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->