### PR TITLE
Migrate to Riverpod v3 and Resolve Analyzer Dependency Conflicts

### DIFF
--- a/lib/src/core/di/dependency_injection.dart
+++ b/lib/src/core/di/dependency_injection.dart
@@ -1,6 +1,5 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/src/core/extensions/riverpod_extensions.dart
+++ b/lib/src/core/extensions/riverpod_extensions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 
 /// Works for sync providers only
 /// Usage: ValueListenable myListenable = ref.asListenable(provider);

--- a/lib/src/core/logger/riverpod_log.dart
+++ b/lib/src/core/logger/riverpod_log.dart
@@ -2,41 +2,34 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'log.dart';
 
-class RiverpodObserver extends ProviderObserver {
+base class RiverpodObserver extends ProviderObserver {
   @override
-  void didAddProvider(
-    ProviderBase<Object?> provider,
-    Object? value,
-    ProviderContainer container,
-  ) {
-    Log.info('Provider $provider was initialized with $value');
+  void didAddProvider(ProviderObserverContext context, Object? value) {
+    Log.info('Provider ${context.provider} was initialized with $value');
   }
 
   @override
-  void didDisposeProvider(
-    ProviderBase<Object?> provider,
-    ProviderContainer container,
-  ) {
-    Log.warning('Provider $provider was disposed');
+  void didDisposeProvider(ProviderObserverContext context) {
+    Log.warning('Provider ${context.provider} was disposed');
   }
 
   @override
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderObserverContext context,
     Object? previousValue,
     Object? newValue,
-    ProviderContainer container,
   ) {
-    Log.info('Provider $provider updated from $previousValue to $newValue');
+    Log.info(
+      'Provider ${context.provider} updated from $previousValue to $newValue',
+    );
   }
 
   @override
   void providerDidFail(
-    ProviderBase<Object?> provider,
+    ProviderObserverContext context,
     Object error,
     StackTrace stackTrace,
-    ProviderContainer container,
   ) {
-    Log.error('Provider $provider threw $error at $stackTrace');
+    Log.error('Provider ${context.provider} threw $error at $stackTrace');
   }
 }

--- a/lib/src/domain/use_cases/reset_repository_use_case.dart
+++ b/lib/src/domain/use_cases/reset_repository_use_case.dart
@@ -1,4 +1,5 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+// ignore: implementation_imports, depend_on_referenced_packages
+import 'package:riverpod/src/framework.dart';
 
 class ResetRepositoryUseCase {
   const ResetRepositoryUseCase();

--- a/lib/src/presentation/core/application_state/startup_provider/app_startup_provider.dart
+++ b/lib/src/presentation/core/application_state/startup_provider/app_startup_provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../core/di/dependency_injection.dart';

--- a/lib/src/presentation/core/router/router.dart
+++ b/lib/src/presentation/core/router/router.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 

--- a/lib/src/presentation/features/authentication/login/view/login_page.dart
+++ b/lib/src/presentation/features/authentication/login/view/login_page.dart
@@ -41,6 +41,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
           ScaffoldMessenger.of(
             context,
           ).showSnackBar(SnackBar(content: Text(error.toString())));
+        default:
       }
     });
   }

--- a/lib/src/presentation/features/home/view/home_page.dart
+++ b/lib/src/presentation/features/home/view/home_page.dart
@@ -28,6 +28,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           ScaffoldMessenger.of(
             context,
           ).showSnackBar(SnackBar(content: Text(error.toString())));
+        default:
       }
     });
   }

--- a/packages/flutter_guardian/pubspec.yaml
+++ b/packages/flutter_guardian/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   analyzer:
   analyzer_plugin:
   # custom_lint_builder will give us tools for writing lints
-  custom_lint_builder: ^0.7.0
+  custom_lint_builder: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,13 +34,13 @@ dependencies:
   cupertino_icons: ^1.0.6
   gap: ^3.0.1
   # State management
-  flutter_riverpod: ^2.5.1
+  flutter_riverpod: ^3.1.0
   # Navigation
   go_router: ^17.0.1
   # Cache & Database
   shared_preferences: ^2.3.1
   # Generator and Annotations
-  riverpod_annotation: ^2.3.5
+  riverpod_annotation: ^4.0.0
   freezed_annotation: ^3.0.0
   # Media
   flutter_svg: ^2.0.10+1
@@ -70,7 +70,7 @@ dev_dependencies:
   riverpod_lint:
   flutter_gen_runner:
   dart_mappable_builder:
-  retrofit_generator: '>=8.0.0 <10.0.0'
+  retrofit_generator: ^10.2.1
   freezed: ^3.0.6
 
 flutter:


### PR DESCRIPTION
## Summary

This PR migrates the project to **Riverpod 3.x** and resolves a chain of dependency conflicts involving `analyzer`, `retrofit_generator`, and `custom_lint_builder`.

The original goal was to fix **Dart 3 exhaustive switch issues** in `retrofit_generator` and upgrade **riverpod** version from v2.x to v3.x. During the upgrade, multiple dependency incompatibilities across the Dart tooling ecosystem arose, and required a coordinated upgrade of several packages.

---

## Why This Change

Older versions of `retrofit_generator` do not support **Dart 3 exhaustive pattern matching**, which resulted in build failures.

Upgrading the generator required moving the project to **`analyzer 8.x`**, which created conflicts with existing linting and Riverpod dependencies.

To resolve this, we aligned all tooling to a compatible version set.

---

## Final Dependency Alignment

| Package | Version | Notes |
|------|------|------|
| `flutter_riverpod` | `^3.1.0` | Supports the newer analyzer |
| `riverpod_annotation` | `^4.0.0` | Compatible with Riverpod v3 |
| `retrofit_generator` | `^10.2.1` | Fixes Dart 3 exhaustive switch issues |
| `custom_lint_builder` | `^0.8.1` | Enables compatibility with analyzer 8 |

This combination provides a **stable dependency state** while supporting Dart 3.

---

## Key Changes

### Dependency Updates
- `flutter_riverpod` **2.5.1 → 3.1.0**
- `riverpod_annotation` → **4.0.0**
- `retrofit_generator` → **10.2.1**
- `custom_lint_builder` → **0.8.1**

### Riverpod v3 Migration
- Updated `RiverpodObserver` implementation to match the **Riverpod v3 API**
- Observer methods now use `ProviderObserverContext`
- Added `base` modifier for `ProviderObserver`

### Code Cleanup
- Removed unnecessary `flutter_riverpod` imports in several files
- Updated internal framework imports in `ResetRepositoryUseCase`

### Compiler Fixes
To satisfy Dart 3 exhaustive checks:
- Added default cases in state listeners

Affected files:
- `login_page.dart`
- `home_page.dart`

---

## Result

- Fixes Dart 3 exhaustive switch build issues
- Upgrades the project to **Riverpod v3**
- Resolves dependency conflicts across analyzer-based tooling
- Establishes a **stable and compatible dependency set**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated framework dependencies to latest versions: flutter_riverpod 3.1.0, riverpod_annotation 4.0.0, retrofit_generator 10.2.1, and custom_lint_builder 0.8.1

* **Bug Fixes**
  * Made switch handling exhaustive in login and home flows to avoid missing-case warnings (no behavioral change)

* **Refactor**
  * Internal observer and runtime integrations updated for compatibility with the newer Riverpod API (no user-facing API changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->