### PR TITLE
feat: Add max and method_lines lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,6 +36,10 @@ linter:
     - prefer_relative_imports
     - require_trailing_commas
     - lines_longer_than_80_chars
+    - max_file_lines:
+        max_lines: 150       # default: 150
+    - max_method_lines:
+        max_lines: 30        # default: 30
 
 formatter:
   page_width: 80

--- a/packages/flutter_guardian/lib/flutter_guardian.dart
+++ b/packages/flutter_guardian/lib/flutter_guardian.dart
@@ -2,16 +2,18 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 import 'rules/rules.dart';
 
-// This is the entrypoint of our custom linter
+/// The entrypoint of the flutter_guardian custom linter plugin.
 PluginBase createPlugin() => _FlutterGuardian();
 
-/// A plugin class is used to list all the assists/lints defined by a plugin.
+/// A plugin class used to list all the assists/lints defined by this plugin.
 class _FlutterGuardian extends PluginBase {
-  /// We list all the custom warnings/infos/errors
+  /// Returns all custom lint rules registered with this plugin.
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
     RepositoryNamingConvention(configs),
     UseCaseNamingConvention(configs),
     ServiceNamingConvention(configs),
+    MaxFileLinesRule(configs),
+    MaxMethodLinesRule(configs),
   ];
 }

--- a/packages/flutter_guardian/lib/rules/max_file_lines_rule.dart
+++ b/packages/flutter_guardian/lib/rules/max_file_lines_rule.dart
@@ -1,0 +1,40 @@
+part of 'rules.dart';
+
+class MaxFileLinesRule extends DartLintRule {
+  // WHY: Factory constructor parses maxLines from configs before delegating to
+  // the private constructor, which needs maxLines at init time for the LintCode message.
+  factory MaxFileLinesRule(CustomLintConfigs configs) {
+    final options = configs.rules['max_file_lines']?.json;
+    final maxLines = options?['max_lines'] as int? ?? 150;
+    return MaxFileLinesRule._(maxLines);
+  }
+
+  MaxFileLinesRule._(this.maxLines)
+    : super(
+        code: LintCode(
+          name: 'max_file_lines',
+          problemMessage:
+              'File exceeds $maxLines lines. Split into smaller files.',
+          correctionMessage:
+              'Extract widgets, utilities, or classes into separate files.',
+          errorSeverity: ErrorSeverity.WARNING,
+        ),
+      );
+
+  final int maxLines;
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((CompilationUnit node) {
+      final lineCount = resolver.lineInfo.lineCount;
+
+      if (lineCount > maxLines) {
+        reporter.atNode(node, code);
+      }
+    });
+  }
+}

--- a/packages/flutter_guardian/lib/rules/max_method_lines_rule.dart
+++ b/packages/flutter_guardian/lib/rules/max_method_lines_rule.dart
@@ -1,0 +1,65 @@
+part of 'rules.dart';
+
+class MaxMethodLinesRule extends DartLintRule {
+  // WHY: Factory constructor parses maxLines from configs before delegating to
+  // the private constructor, which needs maxLines at init time for the LintCode message.
+  factory MaxMethodLinesRule(CustomLintConfigs configs) {
+    final options = configs.rules['max_method_lines']?.json;
+    final maxLines = options?['max_lines'] as int? ?? 30;
+    return MaxMethodLinesRule._(maxLines);
+  }
+
+  MaxMethodLinesRule._(this.maxLines)
+    : super(
+        code: LintCode(
+          name: 'max_method_lines',
+          problemMessage:
+              'Method/function exceeds $maxLines lines. Break it into smaller functions.',
+          correctionMessage:
+              'Extract logic into private helper methods or separate use cases.',
+          errorSeverity: ErrorSeverity.WARNING,
+        ),
+      );
+
+  final int maxLines;
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry
+      ..addMethodDeclaration((MethodDeclaration node) {
+        _checkNodeLength(node, node.name, resolver, reporter);
+      })
+      ..addFunctionDeclaration((FunctionDeclaration node) {
+        _checkNodeLength(node, node.name, resolver, reporter);
+      });
+  }
+
+  void _checkNodeLength(
+    AstNode node,
+    // WHY: dynamic Token — method/function name used for precise error highlighting
+    dynamic nameToken,
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+  ) {
+    final body = _extractBody(node);
+    if (body == null || body is EmptyFunctionBody) return;
+
+    final startLine = resolver.lineInfo.getLocation(body.offset).lineNumber;
+    final endLine = resolver.lineInfo.getLocation(body.end).lineNumber;
+    final lineCount = endLine - startLine + 1;
+
+    if (lineCount > maxLines) {
+      reporter.atToken(nameToken, code);
+    }
+  }
+
+  FunctionBody? _extractBody(AstNode node) {
+    if (node is MethodDeclaration) return node.body;
+    if (node is FunctionDeclaration) return node.functionExpression.body;
+    return null;
+  }
+}

--- a/packages/flutter_guardian/lib/rules/rules.dart
+++ b/packages/flutter_guardian/lib/rules/rules.dart
@@ -3,6 +3,8 @@ import 'package:analyzer/error/error.dart' hide LintCode;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
+part 'max_file_lines_rule.dart';
+part 'max_method_lines_rule.dart';
 part 'repository_naming_lint.dart';
-part 'use_case_naming_lint.dart';
 part 'service_naming_lint.dart';
+part 'use_case_naming_lint.dart';


### PR DESCRIPTION
## Pull request overview

Adds two new custom lint rules to the `flutter_guardian` plugin to enforce maximum file length and maximum method/function length, configurable via `custom_lint` rule configs.

**Changes:**
- Register new `MaxFileLinesRule` and `MaxMethodLinesRule` in the plugin.
- Implement `MaxFileLinesRule` (default 150 lines) and `MaxMethodLinesRule` (default 30 lines) with configurable `max_lines`.
- Update rule part declarations and improve public-facing doc comments in the plugin entrypoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file line limit rule to enforce maximum file sizes. Warns when files exceed 150 lines by default, with configurable limits.
  * Added method line limit rule to enforce maximum method sizes. Warns when methods exceed 30 lines by default, with configurable limits.

* **Documentation**
  * Enhanced plugin entrypoint documentation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->