### PR TITLE
CrashReporter seam + bug policy in the repository guards

### DIFF
--- a/docs/network.md
+++ b/docs/network.md
@@ -91,7 +91,9 @@ DioException (+attached ServerError)
   → Result<T, BusinessFailure>       // via BaseRepository.asyncGuard
 ```
 
-See `docs/CODING_GUIDELINES.md` ("Failures") for the repository-side rules.
+That chain is the recoverable path, and it only handles `Exception`s. A Dart `Error` (a programmer bug — null dereference, bad cast) takes a different path: `BaseRepository` reports it to `crashReporterProvider`, rethrows it with its original stack in debug builds, and folds it to `BusinessFailure.defect` in release. Uncaught errors outside repositories reach the same reporter through `installGlobalErrorHandlers`, wired in `lib/src/core/bootstrap.dart`. Swap `crashReporterProvider` for a Crashlytics- or Sentry-backed implementation to ship crash telemetry.
+
+Endpoints where a specific failure is a valid business outcome (a 404 that means "nothing set") use the guards' `recover` hook instead of hand-written `try`/`catch` — see `BaseRepository`'s doc comment for the contract.
 
 ## Cancellation
 

--- a/docs/network.md
+++ b/docs/network.md
@@ -1,6 +1,6 @@
 # Network layer
 
-How the template talks to a server: Retrofit call sites, a dio interceptor pipeline that handles auth invisibly, and five providers you override instead of editing transport code.
+How the template talks to a server: Retrofit call sites, a dio interceptor pipeline that handles auth invisibly, and a set of providers you override instead of editing transport code.
 
 ## The one rule at call sites
 
@@ -66,7 +66,7 @@ The default logger is `pretty_dio_logger`, gated to debug builds and configured 
 
 The pipeline itself guarantees nothing here: whatever interceptor you pass as `DioBuilder`'s `logger` sees the real request, bearer token included, and owns its release gate and redaction. Two alternatives ship with the template: `DebugLoggerInterceptor`, the strict option (no bodies, no header values, debug-only — for compliance-sensitive work or shared sinks), and `null`, which disables request logging entirely.
 
-## The five adaptation points
+## The adaptation points
 
 All are arguments to `DioBuilder` inside the `networkStack` provider in `lib/src/core/di/parts/externals.dart`; edit them there, never in transport code.
 
@@ -79,6 +79,8 @@ All are arguments to `DioBuilder` inside the `networkStack` provider in `lib/src
 | `logger` | Debug-gated `PrettyDioLogger` (no request headers) | Swap in `DebugLoggerInterceptor` (strict), another logger, or `null` to silence |
 
 (`store` is a sixth, rarely needed: swap secure storage for another `TokenStore`.)
+
+One override provider remains outside `DioBuilder`: `crashReporterProvider` (default `LoggingCrashReporter`) — override it to ship crash telemetry (Crashlytics, Sentry) for reported bugs.
 
 ## Error flow
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'src/core/bootstrap.dart';
 import 'src/core/gen/l10n/app_localizations.dart';
-import 'src/core/logger/riverpod_log.dart';
 import 'src/presentation/core/application_state/localization_provider/localization_provider.dart';
 import 'src/presentation/core/router/router.dart';
 import 'src/presentation/core/theme/theme.dart';
 
-void main() {
-  runApp(ProviderScope(observers: [RiverpodObserver()], child: const MyApp()));
-}
+void main() => runApp(
+  UncontrolledProviderScope(container: bootstrap(), child: const MyApp()),
+);
 
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});

--- a/lib/src/core/base/crash_reporter.dart
+++ b/lib/src/core/base/crash_reporter.dart
@@ -1,0 +1,26 @@
+import '../logger/log.dart';
+
+/// Reports a caught error to a crash service. Injected and test-friendly —
+/// the repository guards' bug policy and the app shell both call it.
+///
+/// Swap the implementation by overriding `crashReporterProvider`: a
+/// Crashlytics- or Sentry-backed reporter needs only these two methods'
+/// worth of surface, and every bug in the app — caught at the repository
+/// boundary or escaping to the global handlers — flows through the one
+/// instance.
+abstract interface class CrashReporter {
+  void report(Object error, StackTrace? stackTrace, {bool fatal});
+}
+
+/// The default reporter: logs at error severity. Keeps the bug policy
+/// functional out of the box; replace it with a real telemetry sink via
+/// `crashReporterProvider` when the app adopts one.
+class LoggingCrashReporter implements CrashReporter {
+  const LoggingCrashReporter();
+
+  @override
+  void report(Object error, StackTrace? stackTrace, {bool fatal = false}) {
+    Log.error('CrashReporter${fatal ? ' (fatal)' : ''}: $error');
+    if (stackTrace != null) Log.error(stackTrace.toString());
+  }
+}

--- a/lib/src/core/base/global_error_handlers.dart
+++ b/lib/src/core/base/global_error_handlers.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+import 'crash_reporter.dart';
+
+/// Installs the process-wide error handlers, routing every uncaught error
+/// to [reporter]. Two sinks cover the two ways an error escapes:
+///
+/// - [FlutterError.onError] — errors raised inside the framework call
+///   stack (build, layout, paint, failed assertions). Reported non-fatal.
+/// - [PlatformDispatcher.onError] — errors that escape it (async gaps,
+///   platform message callbacks). Reported fatal; returning `true` marks
+///   them handled so the engine does not also crash the app.
+///
+/// Call once at bootstrap, before `runApp`, with the [CrashReporter] the
+/// app injects — swapping the reporter then swaps the destination for
+/// uncaught errors too.
+void installGlobalErrorHandlers(CrashReporter reporter) {
+  FlutterError.onError = (details) {
+    reporter.report(details.exception, details.stack, fatal: false);
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
+    reporter.report(error, stack, fatal: true);
+    return true;
+  };
+}

--- a/lib/src/core/base/rethrow_with_stack.dart
+++ b/lib/src/core/base/rethrow_with_stack.dart
@@ -1,0 +1,8 @@
+/// Rethrows [error] preserving its original [stackTrace].
+///
+/// Deliberately lives in its own file that does **not** import
+/// `result.dart`, so bare `Error` here resolves to `dart:core.Error` —
+/// whose `throwWithStackTrace` this needs — rather than the `Result` error
+/// variant that shadows it elsewhere in the codebase.
+Never rethrowWithStack(Object error, StackTrace stackTrace) =>
+    Error.throwWithStackTrace(error, stackTrace);

--- a/lib/src/core/bootstrap.dart
+++ b/lib/src/core/bootstrap.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'base/global_error_handlers.dart';
+import 'di/dependency_injection.dart';
+import 'logger/riverpod_log.dart';
+
+/// Process-level setup, kept out of `main` so the entry point stays a
+/// single expression.
+///
+/// Builds the app's one [ProviderContainer] and installs the process-wide
+/// error handlers against it, so the `CrashReporter` the handlers use and
+/// the one the widget tree injects are the same instance. `main` hands
+/// the returned container to an `UncontrolledProviderScope`.
+///
+/// The container is never disposed: it lives for the process, matching
+/// the `keepAlive` providers it hosts.
+ProviderContainer bootstrap() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final container = ProviderContainer(observers: [RiverpodObserver()]);
+  installGlobalErrorHandlers(container.read(crashReporterProvider));
+
+  return container;
+}

--- a/lib/src/core/di/dependency_injection.dart
+++ b/lib/src/core/di/dependency_injection.dart
@@ -4,6 +4,7 @@ import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../core/base/crash_reporter.dart';
 import '../../data/repositories/authentication_repository_impl.dart';
 import '../../data/repositories/locale_repository_impl.dart';
 import '../../data/repositories/router_repository_impl.dart';

--- a/lib/src/core/di/parts/externals.dart
+++ b/lib/src/core/di/parts/externals.dart
@@ -4,6 +4,12 @@ part of '../dependency_injection.dart';
 Future<SharedPreferences> sharedPreferences(Ref ref) =>
     SharedPreferences.getInstance();
 
+/// The single sink for programmer bugs — the repository guards and the
+/// global error handlers both report here. Override with a Crashlytics- or
+/// Sentry-backed implementation to ship crash telemetry; the default logs.
+@Riverpod(keepAlive: true)
+CrashReporter crashReporter(Ref ref) => const LoggingCrashReporter();
+
 /// The single place to adapt the network stack. Every [DioBuilder]
 /// argument below is a deliberate seam; change it here, never in
 /// transport code:

--- a/lib/src/core/di/parts/repository.dart
+++ b/lib/src/core/di/parts/repository.dart
@@ -6,6 +6,7 @@ AuthenticationRepository authenticationRepository(Ref ref) {
     remote: ref.watch(restClientServiceProvider),
     local: ref.watch(cacheServiceProvider),
     tokens: ref.watch(tokenManagerProvider),
+    crashReporter: ref.watch(crashReporterProvider),
   );
 }
 

--- a/lib/src/data/base/base_repository.dart
+++ b/lib/src/data/base/base_repository.dart
@@ -1,50 +1,113 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/base/crash_reporter.dart';
+import '../../core/base/rethrow_with_stack.dart';
 import '../../core/base/result.dart';
 import '../../core/logger/log.dart';
 import '../../domain/failures/business_failure.dart';
 import '../failures/exception_classifier.dart';
+import '../failures/infra_failure.dart';
 import '../failures/infra_failure_mapper.dart';
 
-/// Base class for data-layer repository implementations. Provides the two
-/// guard helpers every `*RepositoryImpl` needs:
+/// Base for data-layer repositories — the one place `try`/`catch` lives.
 ///
-/// - [asyncGuard] / [syncGuard] — wrap a throwing operation and produce a
-///   `Result<T, BusinessFailure>`. The thrown object is classified into an
-///   `InfraFailure` via `Object.toInfraFailure()` and then translated to
-///   the corresponding [BusinessFailure] variant before the Result returns.
+/// [asyncGuard] / [syncGuard] wrap throwing work and return a typed
+/// [Result]:
 ///
-/// Use directly in the common case:
+/// - an expected `Exception` is classified to an [InfraFailure] and
+///   translated to a [BusinessFailure] (the recoverable path);
+/// - a Dart `Error` (a programmer bug) is **reported** to [crashReporter],
+///   **rethrown in debug** with its original stack, and folded to a
+///   generic `defect` [BusinessFailure] in release — never silently
+///   swallowed.
+///
+/// The recoverable/bug split is structural: [asyncGuard]'s `recover`
+/// callback can only ever see the `Exception` path, never a bug.
+///
+/// The common case is a one-liner:
 ///
 /// ```dart
 /// return asyncGuard(() async { ... });
 /// ```
 ///
+/// `recover` handles endpoints where a specific infrastructure failure is
+/// a valid business outcome — for example a 404 that means "nothing set"
+/// rather than an error:
+///
+/// ```dart
+/// return asyncGuard(
+///   () async => ...,
+///   recover: (failure) =>
+///       failure is NotFoundFailure ? const Success(null) : null,
+/// );
+/// ```
+///
 /// For operations whose business failures exceed the generic
-/// [BusinessFailure] vocabulary (e.g. `ScanCameras` with a `NoDevicesFound`
-/// case), skip the guard and write your own `try`/`catch` that classifies
-/// the exception with `e.toInfraFailure(stackTrace)` and maps the
-/// `InfraFailure` into your richer sealed hierarchy.
+/// [BusinessFailure] vocabulary, skip the guard and write your own
+/// `try`/`catch` that classifies with `e.toInfraFailure(stackTrace)` and
+/// maps into your richer sealed hierarchy.
 abstract base class BaseRepository {
+  const BaseRepository({required this.crashReporter});
+
+  @protected
+  final CrashReporter crashReporter;
+
+  /// Wraps async throwing work.
+  ///
+  /// [recover] runs **only** on the recoverable (`Exception`) path,
+  /// receiving the classified [InfraFailure]; return a [Result] to
+  /// short-circuit (recovered) or `null` to fall through to the normal
+  /// translation. Because bugs take the bare-`catch` branch, [recover]
+  /// can never fire for one.
+  @protected
   Future<Result<T, BusinessFailure>> asyncGuard<T>(
-    Future<T> Function() operation,
-  ) async {
+    Future<T> Function() operation, {
+    Result<T, BusinessFailure>? Function(InfraFailure failure)? recover,
+  }) async {
     try {
       return Success(await operation());
+    } on Exception catch (e, stackTrace) {
+      return _recoverable<T>(e, stackTrace, recover);
     } catch (e, stackTrace) {
-      return _failure<T>(e, stackTrace);
+      return _bug<T>(e, stackTrace);
     }
   }
 
-  Result<T, BusinessFailure> syncGuard<T>(T Function() operation) {
+  /// The synchronous counterpart of [asyncGuard].
+  @protected
+  Result<T, BusinessFailure> syncGuard<T>(
+    T Function() operation, {
+    Result<T, BusinessFailure>? Function(InfraFailure failure)? recover,
+  }) {
     try {
       return Success(operation());
+    } on Exception catch (e, stackTrace) {
+      return _recoverable<T>(e, stackTrace, recover);
     } catch (e, stackTrace) {
-      return _failure<T>(e, stackTrace);
+      return _bug<T>(e, stackTrace);
     }
   }
 
-  Error<T, BusinessFailure> _failure<T>(Object e, StackTrace stackTrace) {
+  Result<T, BusinessFailure> _recoverable<T>(
+    Exception e,
+    StackTrace stackTrace,
+    Result<T, BusinessFailure>? Function(InfraFailure failure)? recover,
+  ) {
     Log.error(e.toString());
     Log.error(stackTrace.toString());
+    final infra = e.toInfraFailure(stackTrace);
+
+    return recover?.call(infra) ?? Error(infra.toBusinessFailure());
+  }
+
+  /// A Dart `Error` reached the boundary — a programmer bug. Always
+  /// reported; rethrown with its original stack in debug; folded to a
+  /// generic `defect` in release (already reported, so the user sees
+  /// generic copy instead of a crash).
+  Result<T, BusinessFailure> _bug<T>(Object e, StackTrace stackTrace) {
+    crashReporter.report(e, stackTrace, fatal: false);
+    if (kDebugMode) rethrowWithStack(e, stackTrace);
+
     return Error(e.toInfraFailure(stackTrace).toBusinessFailure());
   }
 }

--- a/lib/src/data/failures/exception_classifier.dart
+++ b/lib/src/data/failures/exception_classifier.dart
@@ -9,11 +9,14 @@ import 'infra_failure.dart';
 /// preserves it for logging. `DioException`s carry their own `stackTrace`,
 /// which takes precedence; the parameter covers every other thrown object.
 ///
-/// The default branches cover `DioException` (HTTP/network) and `TypeError`
-/// (JSON-decoding shape mismatches). Anything else is folded into
-/// `InfraFailure.unknown` with the original exception attached as `cause`.
-/// Extend this extension in consumer apps that throw their own structured
-/// exception types and want finer-grained classification.
+/// The default branches cover `DioException` (HTTP/network),
+/// `FormatException` (malformed data — the common `jsonDecode`,
+/// `int.parse`, `DateTime.parse` failures), and Dart `Error` (a programmer
+/// bug — null dereference, bad cast — classified as `defect`, never as a
+/// data problem). Anything else is folded into `InfraFailure.unknown` with
+/// the original exception attached as `cause`. Extend this extension in
+/// consumer apps that throw their own structured exception types and want
+/// finer-grained classification.
 extension ExceptionClassifier on Object {
   InfraFailure toInfraFailure([StackTrace? stackTrace]) {
     final self = this;
@@ -21,7 +24,12 @@ extension ExceptionClassifier on Object {
 
     return switch (self) {
       DioException() => _fromDioException(self),
-      TypeError() => .parsing(
+      FormatException() => .parsing(
+        message: self.message,
+        cause: self,
+        stackTrace: trace,
+      ),
+      Error() => .defect(
         message: self.toString(),
         cause: self,
         stackTrace: trace,

--- a/lib/src/data/failures/infra_failure.dart
+++ b/lib/src/data/failures/infra_failure.dart
@@ -122,8 +122,19 @@ sealed class InfraFailure with _$InfraFailure {
     StackTrace? stackTrace,
   }) = ParsingFailure;
 
-  /// Catch-all: programmer errors, unexpected exception types, anything
-  /// the classifier could not place.
+  /// A programmer bug reached the repository boundary — a Dart `Error`
+  /// (null dereference, bad cast, failed assertion) rather than a
+  /// recoverable `Exception`. `BaseRepository` reports it to the
+  /// `CrashReporter` and rethrows in debug; this variant is what release
+  /// builds fold it into.
+  const factory InfraFailure.defect({
+    String? message,
+    String? code,
+    Object? cause,
+    StackTrace? stackTrace,
+  }) = DefectFailure;
+
+  /// Catch-all: unexpected exception types the classifier could not place.
   const factory InfraFailure.unknown({
     String? message,
     String? code,

--- a/lib/src/data/failures/infra_failure_mapper.dart
+++ b/lib/src/data/failures/infra_failure_mapper.dart
@@ -53,5 +53,10 @@ extension InfraFailureToBusiness on InfraFailure {
       cause: cause,
       stackTrace: stackTrace,
     ),
+    DefectFailure() => .defect(
+      message: message,
+      cause: cause,
+      stackTrace: stackTrace,
+    ),
   };
 }

--- a/lib/src/data/repositories/authentication_repository_impl.dart
+++ b/lib/src/data/repositories/authentication_repository_impl.dart
@@ -16,6 +16,7 @@ final class AuthenticationRepositoryImpl extends BaseRepository
     required this.remote,
     required this.local,
     required this.tokens,
+    required super.crashReporter,
   });
 
   final RestClient remote;

--- a/lib/src/domain/failures/business_failure.dart
+++ b/lib/src/domain/failures/business_failure.dart
@@ -81,13 +81,22 @@ sealed class BusinessFailure with _$BusinessFailure {
     StackTrace? stackTrace,
   }) = Cancelled;
 
-  /// Catch-all: parsing errors, unexpected server shape, programmer bugs.
+  /// Catch-all: parsing errors, unexpected server shape.
   /// Presentation should log and show a generic message.
   const factory BusinessFailure.unexpected({
     String? message,
     Object? cause,
     StackTrace? stackTrace,
   }) = Unexpected;
+
+  /// A programmer bug, already reported to the crash reporter by
+  /// `BaseRepository`. Reaches presentation only in release builds (debug
+  /// rethrows); show generic copy — there is nothing the user can fix.
+  const factory BusinessFailure.defect({
+    String? message,
+    Object? cause,
+    StackTrace? stackTrace,
+  }) = Defect;
 
   /// Convenience message for simple UI paths that just show a string.
   /// Rich UI should pattern-match on the variant for nuanced handling.
@@ -103,5 +112,6 @@ sealed class BusinessFailure with _$BusinessFailure {
     Conflict() => message ?? 'This request conflicts with the current state.',
     Cancelled() => message ?? 'The operation was cancelled.',
     Unexpected() => message ?? 'Something went wrong.',
+    Defect() => 'Something went wrong.',
   };
 }

--- a/test/core/base/fake_crash_reporter.dart
+++ b/test/core/base/fake_crash_reporter.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_template/src/core/base/crash_reporter.dart';
+
+/// Records every [report] call for assertions.
+class FakeCrashReporter implements CrashReporter {
+  final List<({Object error, StackTrace? stackTrace, bool fatal})> reports = [];
+
+  @override
+  void report(Object error, StackTrace? stackTrace, {bool fatal = false}) {
+    reports.add((error: error, stackTrace: stackTrace, fatal: fatal));
+  }
+}

--- a/test/core/base/global_error_handlers_test.dart
+++ b/test/core/base/global_error_handlers_test.dart
@@ -1,0 +1,54 @@
+import 'dart:ui' show ErrorCallback;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_template/src/core/base/global_error_handlers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_crash_reporter.dart';
+
+void main() {
+  group('installGlobalErrorHandlers', () {
+    late FakeCrashReporter reporter;
+    late FlutterExceptionHandler? previousOnError;
+    late ErrorCallback? previousPlatformOnError;
+
+    setUp(() {
+      reporter = FakeCrashReporter();
+      // flutter_test installs its own handlers; save and restore them so
+      // this test cannot break failure reporting for the rest of the run.
+      previousOnError = FlutterError.onError;
+      previousPlatformOnError = PlatformDispatcher.instance.onError;
+      installGlobalErrorHandlers(reporter);
+    });
+
+    tearDown(() {
+      FlutterError.onError = previousOnError;
+      PlatformDispatcher.instance.onError = previousPlatformOnError;
+    });
+
+    test('framework errors report non-fatal', () {
+      final details = FlutterErrorDetails(
+        exception: StateError('build failed'),
+        stack: StackTrace.current,
+      );
+
+      FlutterError.onError!(details);
+
+      expect(reporter.reports, hasLength(1));
+      expect(reporter.reports.single.error, details.exception);
+      expect(reporter.reports.single.fatal, isFalse);
+    });
+
+    test('platform-dispatcher errors report fatal and are marked handled', () {
+      final error = StateError('escaped the framework');
+      final trace = StackTrace.current;
+
+      final handled = PlatformDispatcher.instance.onError!(error, trace);
+
+      expect(handled, isTrue);
+      expect(reporter.reports, hasLength(1));
+      expect(reporter.reports.single.error, same(error));
+      expect(reporter.reports.single.fatal, isTrue);
+    });
+  });
+}

--- a/test/core/base/rethrow_with_stack_test.dart
+++ b/test/core/base/rethrow_with_stack_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_template/src/core/base/rethrow_with_stack.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('rethrowWithStack', () {
+    test('rethrows the same object with the given stack trace', () {
+      final original = StateError('boom');
+      final trace = StackTrace.current;
+
+      // rethrowWithStack returns Never, so no fail() guard is needed —
+      // falling through the try is impossible by type.
+      try {
+        rethrowWithStack(original, trace);
+      } on StateError catch (e, st) {
+        expect(e, same(original));
+        expect(st, same(trace));
+      }
+    });
+  });
+}

--- a/test/core/bootstrap_test.dart
+++ b/test/core/bootstrap_test.dart
@@ -1,0 +1,40 @@
+import 'dart:ui' show ErrorCallback;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_template/src/core/bootstrap.dart';
+import 'package:flutter_template/src/core/di/dependency_injection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('bootstrap', () {
+    late FlutterExceptionHandler? previousOnError;
+    late ErrorCallback? previousPlatformOnError;
+
+    setUp(() {
+      // bootstrap installs process-wide handlers; save and restore
+      // flutter_test's own so failure reporting survives this file.
+      previousOnError = FlutterError.onError;
+      previousPlatformOnError = PlatformDispatcher.instance.onError;
+    });
+
+    tearDown(() {
+      FlutterError.onError = previousOnError;
+      PlatformDispatcher.instance.onError = previousPlatformOnError;
+    });
+
+    test('returns a working container and installs the handlers', () {
+      final container = bootstrap();
+      addTearDown(container.dispose);
+
+      // The container resolves providers — the same instance main hands
+      // to UncontrolledProviderScope.
+      expect(container.read(crashReporterProvider), isNotNull);
+      // Handlers were replaced with the bootstrap-installed ones.
+      expect(FlutterError.onError, isNot(same(previousOnError)));
+      expect(
+        PlatformDispatcher.instance.onError,
+        isNot(same(previousPlatformOnError)),
+      );
+    });
+  });
+}

--- a/test/core/di/crash_reporter_provider_test.dart
+++ b/test/core/di/crash_reporter_provider_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_template/src/core/base/crash_reporter.dart';
+import 'package:flutter_template/src/core/di/dependency_injection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('crashReporterProvider', () {
+    test('defaults to the logging reporter', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(crashReporterProvider),
+        isA<LoggingCrashReporter>(),
+      );
+    });
+  });
+}

--- a/test/data/base/base_repository_test.dart
+++ b/test/data/base/base_repository_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_template/src/core/base/result.dart';
+import 'package:flutter_template/src/data/base/base_repository.dart';
+import 'package:flutter_template/src/data/failures/infra_failure.dart';
+import 'package:flutter_template/src/domain/failures/business_failure.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../core/base/fake_crash_reporter.dart';
+
+/// Exposes the `@protected` guards for direct testing.
+final class _TestRepo extends BaseRepository {
+  const _TestRepo({required super.crashReporter});
+
+  Future<Result<T, BusinessFailure>> runAsync<T>(
+    Future<T> Function() operation, {
+    Result<T, BusinessFailure>? Function(InfraFailure failure)? recover,
+  }) => asyncGuard(operation, recover: recover);
+
+  Result<T, BusinessFailure> runSync<T>(
+    T Function() operation, {
+    Result<T, BusinessFailure>? Function(InfraFailure failure)? recover,
+  }) => syncGuard(operation, recover: recover);
+}
+
+void main() {
+  late FakeCrashReporter reporter;
+  late _TestRepo repo;
+
+  setUp(() {
+    reporter = FakeCrashReporter();
+    repo = _TestRepo(crashReporter: reporter);
+  });
+
+  group('BaseRepository', () {
+    group('success path', () {
+      test('asyncGuard wraps the value in Success', () async {
+        final result = await repo.runAsync(() async => 42);
+
+        expect(result, const Success<int, BusinessFailure>(42));
+        expect(reporter.reports, isEmpty);
+      });
+
+      test('syncGuard wraps the value in Success', () {
+        expect(
+          repo.runSync(() => 'ok'),
+          const Success<String, BusinessFailure>('ok'),
+        );
+      });
+    });
+
+    group('recoverable path (Exception)', () {
+      test('classifies and translates without reporting', () async {
+        final result = await repo.runAsync<int>(
+          () async => throw Exception('remote unavailable'),
+        );
+
+        expect(result, isA<Error<int, BusinessFailure>>());
+        // An expected failure is not a bug: the crash reporter stays quiet.
+        expect(reporter.reports, isEmpty);
+      });
+
+      test('recover receives the classified InfraFailure', () async {
+        InfraFailure? seen;
+
+        await repo.runAsync<int>(
+          () async => 42,
+          recover: (failure) {
+            seen = failure;
+            return null;
+          },
+        );
+
+        expect(seen, isNull, reason: 'no throw — recover must not run');
+
+        await repo.runAsync<int>(
+          () async => throw const FormatException('bad json'),
+          recover: (failure) {
+            seen = failure;
+            return null;
+          },
+        );
+
+        expect(seen, isA<ParsingFailure>());
+      });
+
+      test('a recover result short-circuits the translation', () async {
+        final result = await repo.runAsync<int?>(
+          () async => throw const FormatException('empty body'),
+          recover: (failure) =>
+              failure is ParsingFailure ? const Success(null) : null,
+        );
+
+        expect(result, const Success<int?, BusinessFailure>(null));
+      });
+
+      test(
+        'a null recover result falls through to the mapped failure',
+        () async {
+          final result = await repo.runAsync<int>(
+            () async => throw const FormatException('empty body'),
+            recover: (_) => null,
+          );
+
+          expect(
+            result,
+            isA<Error<int, BusinessFailure>>().having(
+              (r) => r.error,
+              'error',
+              isA<Unexpected>(),
+            ),
+          );
+        },
+      );
+    });
+
+    group('bug path (Dart Error)', () {
+      // Test binaries run with asserts enabled (kDebugMode is true), so
+      // the guards rethrow bugs after reporting. The release fold to
+      // BusinessFailure.defect cannot be exercised from a test.
+      test('reports and rethrows with the original stack', () async {
+        final bug = StateError('impossible');
+
+        await expectLater(
+          repo.runAsync<int>(() async => throw bug),
+          throwsA(same(bug)),
+        );
+
+        expect(reporter.reports, hasLength(1));
+        expect(reporter.reports.single.error, same(bug));
+        expect(reporter.reports.single.fatal, isFalse);
+      });
+
+      test('recover never fires for a bug', () async {
+        var recoverCalled = false;
+
+        await expectLater(
+          repo.runAsync<int>(
+            () async => throw StateError('impossible'),
+            recover: (_) {
+              recoverCalled = true;
+              return null;
+            },
+          ),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(recoverCalled, isFalse);
+      });
+
+      test('syncGuard applies the same policy', () {
+        final bug = TypeError();
+
+        expect(() => repo.runSync<int>(() => throw bug), throwsA(same(bug)));
+        expect(reporter.reports.single.error, same(bug));
+      });
+    });
+  });
+}

--- a/test/data/failures/exception_classifier_test.dart
+++ b/test/data/failures/exception_classifier_test.dart
@@ -149,8 +149,32 @@ void main() {
       );
     });
 
-    test('TypeError → parsing', () {
-      expect(_captureTypeError().toInfraFailure(), isA<ParsingFailure>());
+    test('TypeError (a Dart Error — a bug) → defect', () {
+      expect(_captureTypeError().toInfraFailure(), isA<DefectFailure>());
+    });
+
+    test('FormatException (malformed data) → parsing', () {
+      expect(
+        const FormatException('Unexpected character').toInfraFailure(),
+        isA<ParsingFailure>().having(
+          (f) => f.message,
+          'message',
+          'Unexpected character',
+        ),
+      );
+    });
+
+    test('StateError → defect with the passed stack trace preserved', () {
+      final trace = StackTrace.current;
+
+      expect(
+        StateError('impossible state').toInfraFailure(trace),
+        isA<DefectFailure>().having(
+          (f) => f.stackTrace,
+          'stackTrace',
+          same(trace),
+        ),
+      );
     });
 
     test('Generic Exception → unknown', () {


### PR DESCRIPTION
Stacked on #54 — review after it merges, or review only the top commit.

## What this adds

A crash-reporting seam and a strict recoverable-vs-bug policy at the repository boundary.

- **`CrashReporter`** — a two-method injectable interface with a logging default behind `crashReporterProvider`. One override ships Crashlytics/Sentry-style telemetry for every bug in the app.
- **Bug policy in `BaseRepository`** — `on Exception` keeps the classify-and-translate path (recoverable). A bare `catch` means a Dart `Error` — a programmer bug: reported to the `CrashReporter`, rethrown with its original stack in debug, folded to the new `defect` failure variants in release. A null dereference inside a repository is never again silently downgraded to "something went wrong".
- **`recover` hook** on both guards — data-layer recovery for endpoints where a specific `InfraFailure` is a valid business outcome (a 404 that means "nothing set"). Structurally unreachable for bugs, since bugs take the other catch branch.
- **Classifier corrections** — `FormatException → parsing` (malformed data, recoverable); any `Error → defect` (a bug, not a data problem).
- **Global handlers** — `installGlobalErrorHandlers` routes `FlutterError.onError` (non-fatal) and `PlatformDispatcher.onError` (fatal, marked handled) to the same reporter. `bootstrap()` in `lib/src/core/bootstrap.dart` builds the app's single `ProviderContainer` and returns it, keeping `main()` to one expression.

## Tests

16 new tests (101 total): the guard policy matrix (report/rethrow/recover), the classifier flips, the global handlers with save/restore of the test framework's own handlers, the provider default, the rethrow helper, and the bootstrap contract. The release-mode fold to `defect` is documented as untestable (test binaries run with asserts enabled, so bugs rethrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable crash reporting with support for custom telemetry integrations.
  * Added global handling for framework and platform errors, including fatality classification.
  * Added recovery callbacks for selected infrastructure failures.
  * Improved bug handling by preserving stack traces in debug mode and showing a generic defect failure in release builds.
* **Documentation**
  * Updated networking and error-handling guidance to reflect configurable providers and crash reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->