### PR TITLE
Router reshape: typed routes, derived gate, token-aware session

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ flutter_template/
 ├── docs/                    # Project documentation
 │   ├── architecture.md         # Architecture documentation
 │   ├── dependency_injection.md # DI system documentation
-│   └── authentication_feature.md # Authentication feature docs
+│   ├── network.md              # Network layer guide
+│   └── router.md               # Routing and gate model guide
 ├── lib/
 │   ├── src/
 │   │   ├── core/               # Core utilities
@@ -184,14 +185,14 @@ flutter_template/
 - **Login**: Email/password authentication with validation
 - **Registration**: User signup with form validation
 - **Password Reset**: Complete forgot password flow
-- **Remember Me**: Persistent login state management
+- **Remember Me**: Opting in keeps the stored tokens across restarts; opting out clears them on the next launch
 - **Logout**: Secure session termination
 - **Token Management**: Automatic token refresh and storage
 
 ### Navigation & Routing
 - **Declarative Routing**: Type-safe navigation with go_router
 - **Nested Routes**: Complex navigation hierarchies
-- **Route Guards**: Authentication-based route protection
+- **Route Guards**: A single derived gate covering startup, onboarding, and authentication
 - **Deep Linking**: URL-based navigation support
 - **Shell Routes**: Persistent navigation elements
 
@@ -272,17 +273,7 @@ class UserState extends _$UserState {
 
 ### Adding New Routes
 
-```dart
-// 1. Define route in presentation/core/router/routes.dart
-static const String newFeature = '/new-feature';
-
-// 2. Add route in appropriate route file
-GoRoute(
-  path: Routes.newFeature,
-  name: Routes.newFeature,
-  builder: (context, state) => const NewFeaturePage(),
-),
-```
+Add a member to the `Routes` enum, register it in the matching `parts/<feature>_routes.dart` file, and decide how the gate treats it. The full recipe, the gate model, and the navigation rules are in [docs/router.md](docs/router.md).
 
 ## Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,8 @@ The project uses **go_router** for navigation, which provides:
 - Nested navigation
 - Route guards
 
+Gating is a single pure derivation: `routerStateProvider` folds startup, onboarding, and session status into one destination, and `RedirectGate.redirect` is the entire policy. Pages never navigate on auth changes; they invalidate a status provider and the gate follows. See `docs/router.md` for the gate model and the route-adding recipe.
+
 ## Key Dependencies
 
 - **State Management**: `flutter_riverpod`

--- a/docs/network.md
+++ b/docs/network.md
@@ -58,7 +58,7 @@ On a 401 whose request went out carrying a token, `RefreshRetryInterceptor` refr
 
 The wire contract is the one backend-specific piece: a `POST` to `Endpoints.refreshToken` (`/auth/refresh`) with `{"refreshToken": …}` in the body, response parsed for `accessToken` (required) and `refreshToken` (optional rotation). All of it lives in `TokenManager._performRefresh` — the single method to adapt when your backend differs.
 
-Session lifecycle from the app side: `tokens.persist(...)` after login, `tokens.clear()` on logout (see `AuthenticationRepositoryImpl`).
+Session lifecycle from the app side: `tokens.persist(...)` after login, `tokens.clear()` on logout, and `restoreSession()` at startup, which clears a previous run's tokens unless the user asked to be remembered (see `AuthenticationRepositoryImpl`). The router's session gate reads the stored refresh token — the tokens, not a cached flag, decide whether the user is signed in.
 
 ## Logging and redaction
 

--- a/docs/router.md
+++ b/docs/router.md
@@ -1,0 +1,61 @@
+# Router
+
+How navigation works: one route enum, one derived gate, and a redirect policy that is pure and unit-tested. The router reads a single provider and enforces its decision; nothing else navigates on app-state changes.
+
+## The one rule
+
+Pages never push routes in response to auth, startup, or onboarding changes. They change the underlying state and invalidate the matching status provider; the gate does the navigation.
+
+| After | Invalidate | The gate then |
+|---|---|---|
+| Successful login | `sessionStatusProvider` | Redirects to home |
+| Logout | `sessionStatusProvider` | Redirects to login |
+| Onboarding completed | `onboardingStatusProvider` | Redirects to login or home |
+
+Pushing a route imperatively in these situations races the gate: the gate may redirect the push away, or the push may land on a route the gate immediately bounces. Ordinary in-app navigation (a detail screen, a form step) still uses `context.pushNamed(Routes.x.name)` as usual — the gate does not interfere with routes the current gate allows.
+
+## The gate
+
+`routerStateProvider` derives one destination from three inputs, in priority order:
+
+1. **Startup pending or failed** → `Routes.splash`. The splash route hosts the startup widget, so a failed startup shows its retry UI.
+2. **Onboarding not completed** → `Routes.onboarding`.
+3. **Session** → `Routes.home` when a session exists, `Routes.login` otherwise. While the session status is still loading, the gate stays on splash.
+
+Session status derives from the stored refresh token — see the session lifecycle section of [network.md](network.md). New gating inputs (a force-update screen, a maintenance mode) compose here, as another early return in `routerState`; the router itself never changes.
+
+`RedirectGate.redirect(path, gate)` turns that destination into a redirect decision:
+
+| Gate | Pinned to | Allowed | Everything else |
+|---|---|---|---|
+| `splash` | `/splash` | — | → `/splash` |
+| `onboarding` | `/onboarding` | — | → `/onboarding` |
+| `login` | — | `/login` and every route nested under it | → `/login` |
+| `home` (authenticated) | — | all app routes | auth flow, splash, onboarding, `/` → `/home` |
+
+The function is pure — no `Ref`, no `BuildContext` — and idempotent: it never returns the path already being visited, which is what prevents redirect loops. A path no gate handles and no route matches lands on `NotFoundScreen` via the router's `errorBuilder`.
+
+## Adding a route
+
+1. Add a member to the `Routes` enum in `presentation/core/router/routes.dart`. Top-level routes carry an absolute path (leading `/`); sub-routes carry a relative segment and nest under their parent.
+2. Register it in the matching `parts/<feature>_routes.dart` file:
+
+```dart
+GoRoute(
+  path: Routes.newFeature.path,
+  name: Routes.newFeature.name,
+  pageBuilder: (context, state) =>
+      const MaterialPage(child: NewFeaturePage()),
+),
+```
+
+3. Decide how the gate treats it. A route inside the authenticated area needs no change — the `home` gate allows it. A route that must be reachable while signed out belongs in `RedirectGate`'s auth-flow set, with a test.
+
+Route paths and names exist only on the enum. Never declare a path string anywhere else; `GoRoute.path`, `GoRoute.name`, and every navigation call read the same member, so the two cannot drift.
+
+## Testing
+
+`test/presentation/core/router/` holds the patterns:
+
+- `redirect_gate_test.dart` — the policy matrix: what each gate pins, allows, and redirects, including idempotency. Pure function in, expectation out; no widgets, no router.
+- `router_state_test.dart` — the derivation: override the startup, onboarding, and session providers in a `ProviderContainer` and assert the resulting gate. The container disables provider auto-retry to match the app's root scope, so failures settle instead of silently retrying.

--- a/lib/src/core/base/unit.dart
+++ b/lib/src/core/base/unit.dart
@@ -26,7 +26,8 @@
 /// ```dart
 /// Future<Result<Unit, BusinessFailure>> logout() async {
 ///   return asyncGuard(() async {
-///     await local.remove([CacheKey.isLoggedIn]);
+///     await local.remove([CacheKey.isLoggedIn, CacheKey.rememberMe]);
+///     await tokens.clear();
 ///     return Unit.value;
 ///   });
 /// }
@@ -39,7 +40,7 @@
 /// final result = await repo.logout();
 /// switch (result) {
 ///   case Success():
-///     navigateToLogin();
+///     ref.invalidate(sessionStatusProvider); // the gate navigates
 ///   case Error(:final error):
 ///     showError(error.userMessage);
 /// }
@@ -86,7 +87,7 @@
 ///
 /// ```dart
 /// // BAD — constructing Unit directly bypasses the canonical value.
-/// // Won't compile anyway (private constructor), but listed for clarity.
+/// // Will not compile anyway (private constructor), but listed for clarity.
 /// final myUnit = Unit();
 ///
 /// // BAD — using Unit on a plain non-Result function.

--- a/lib/src/core/bootstrap.dart
+++ b/lib/src/core/bootstrap.dart
@@ -18,7 +18,15 @@ import 'logger/riverpod_log.dart';
 ProviderContainer bootstrap() {
   WidgetsFlutterBinding.ensureInitialized();
 
-  final container = ProviderContainer(observers: [RiverpodObserver()]);
+  final container = ProviderContainer(
+    // WHY: Riverpod 3 retries failed providers with backoff by default,
+    // which breaks fail-fast semantics — the router gate shows splash
+    // with retry UI on a startup failure, and a silently retrying
+    // provider would never settle into that error state. Opt back in
+    // per provider where a retry is genuinely wanted.
+    retry: (retryCount, error) => null,
+    observers: [RiverpodObserver()],
+  );
   installGlobalErrorHandlers(container.read(crashReporterProvider));
 
   return container;

--- a/lib/src/core/di/parts/repository.dart
+++ b/lib/src/core/di/parts/repository.dart
@@ -12,7 +12,10 @@ AuthenticationRepository authenticationRepository(Ref ref) {
 
 @Riverpod(keepAlive: true)
 RouterRepository routerRepository(Ref ref) {
-  return RouterRepositoryImpl(cacheService: ref.watch(cacheServiceProvider));
+  return RouterRepositoryImpl(
+    cacheService: ref.watch(cacheServiceProvider),
+    tokens: ref.watch(tokenManagerProvider),
+  );
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/src/core/di/parts/use_cases.dart
+++ b/lib/src/core/di/parts/use_cases.dart
@@ -31,8 +31,13 @@ GetOnboardingStatusUseCase getOnboardingStatusUseCase(Ref ref) {
 }
 
 @riverpod
-GetUserLoginStatusUseCase getUserLoginStatusUseCase(Ref ref) {
-  return GetUserLoginStatusUseCase(ref.read(routerRepositoryProvider));
+GetSessionStatusUseCase getSessionStatusUseCase(Ref ref) {
+  return GetSessionStatusUseCase(ref.read(routerRepositoryProvider));
+}
+
+@riverpod
+RestoreSessionUseCase restoreSessionUseCase(Ref ref) {
+  return RestoreSessionUseCase(ref.read(authenticationRepositoryProvider));
 }
 
 @riverpod

--- a/lib/src/core/extensions/go_router_extension.dart
+++ b/lib/src/core/extensions/go_router_extension.dart
@@ -2,6 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 extension GoRouterExtension on BuildContext {
+  /// Empties the current navigator stack, then replaces the remaining
+  /// route with [routeName] — for terminal flow exits (for example,
+  /// registration complete → back to login) where the stack behind must
+  /// not be reachable. Never use it for auth-state changes; those are
+  /// gate-driven (invalidate the status provider and the router
+  /// redirects).
   void pushNamedAndRemoveUntil(String routeName) {
     while (canPop()) {
       pop();

--- a/lib/src/core/extensions/riverpod_extensions.dart
+++ b/lib/src/core/extensions/riverpod_extensions.dart
@@ -2,8 +2,18 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 
-/// Works for sync providers only
-/// Usage: ValueListenable myListenable = ref.asListenable(provider);
+/// Bridges a synchronous provider to a [ValueListenable] — the shape
+/// `GoRouter.refreshListenable` expects.
+///
+/// The returned notifier and its provider subscription live as long as
+/// the calling [Ref] and are released on its dispose. Call it **once**
+/// in the provider body and reuse the result; calling it inside a
+/// callback (for example a router `redirect`) allocates a new
+/// subscription per invocation that a `keepAlive` provider never
+/// releases.
+///
+/// Synchronous providers only — an async provider has no current value
+/// to seed the notifier with.
 extension RefAsListenable on Ref {
   ValueListenable<T> asListenable<T>(ProviderBase<T> provider) {
     final valueNotifier = ValueNotifier(read(provider));
@@ -17,7 +27,7 @@ extension RefAsListenable on Ref {
 
     onResume(() {
       final latestValue = read(provider);
-      // Again, only update if there's a change
+      // Only update when the value changed
       if (valueNotifier.value != latestValue) {
         valueNotifier.value = latestValue;
       }

--- a/lib/src/core/localization/intl_ar.arb
+++ b/lib/src/core/localization/intl_ar.arb
@@ -80,5 +80,14 @@
     "passwordLowerCaseValidation": "يجب أن تحتوي كلمة المرور على حرف صغير واحد على الأقل",
     "passwordUpperCaseValidation": "يجب أن تحتوي كلمة المرور على حرف كبير واحد على الأقل",
     "passwordSpecialCharValidation": "يجب أن تحتوي كلمة المرور على رمز خاص واحد على الأقل",
-    "passwordMismatchValidation": "كلمات المرور غير متطابقة"
+    "passwordMismatchValidation": "كلمات المرور غير متطابقة",
+    "goHome": "العودة إلى الصفحة الرئيسية",
+    "noRouteFor": "لا يوجد مسار لـ '{uri}'",
+    "@noRouteFor": {
+        "placeholders": {
+            "uri": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/lib/src/core/localization/intl_bn.arb
+++ b/lib/src/core/localization/intl_bn.arb
@@ -80,5 +80,14 @@
     "passwordLowerCaseValidation": "পাসওয়ার্ডে কমপক্ষে একটি ছোট হাতের অক্ষর থাকতে হবে",
     "passwordUpperCaseValidation": "পাসওয়ার্ডে কমপক্ষে একটি বড় হাতের অক্ষর থাকতে হবে",
     "passwordSpecialCharValidation": "পাসওয়ার্ডে কমপক্ষে একটি বিশেষ অক্ষর থাকতে হবে",
-    "passwordMismatchValidation": "পাসওয়ার্ড মিলছে না"
+    "passwordMismatchValidation": "পাসওয়ার্ড মিলছে না",
+    "goHome": "হোমে ফিরে যান",
+    "noRouteFor": "'{uri}' এর জন্য কোনো রুট পাওয়া যায়নি",
+    "@noRouteFor": {
+        "placeholders": {
+            "uri": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/lib/src/core/localization/intl_en.arb
+++ b/lib/src/core/localization/intl_en.arb
@@ -9,7 +9,7 @@
     "createNewPasswordHint": "Your new password must be different from previous used passwords.",
     "resetPassword": "Reset Password",
     "newPassword": "New Password",
-    "passwordChangeSuccess":"Password Changed Successfully",
+    "passwordChangeSuccess": "Password Changed Successfully",
     "emailRequired": "Email is required",
     "passwordRequired": "Password is required",
     "isRequired": "This field is required",
@@ -80,5 +80,14 @@
     "passwordLowerCaseValidation": "Password must contain at least one lowercase letter",
     "passwordUpperCaseValidation": "Password must contain at least one uppercase letter",
     "passwordSpecialCharValidation": "Password must contain at least one special character",
-    "passwordMismatchValidation": "Passwords do not match"
+    "passwordMismatchValidation": "Passwords do not match",
+    "goHome": "Go home",
+    "noRouteFor": "No route found for '{uri}'",
+    "@noRouteFor": {
+        "placeholders": {
+            "uri": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/lib/src/data/repositories/authentication_repository_impl.dart
+++ b/lib/src/data/repositories/authentication_repository_impl.dart
@@ -63,11 +63,12 @@ final class AuthenticationRepositoryImpl extends BaseRepository
     await local.save(CacheKey.isLoggedIn, true);
   }
 
-  /// Manages the "Remember Me" functionality.
+  /// Reads or writes the persisted "Remember Me" checkbox preference.
   ///
-  /// When [rememberMe] is null, retrieves the current setting from cache.
-  /// When [rememberMe] has a value, updates the setting in cache.
-  /// Returns the current or newly saved value, defaulting to false on errors.
+  /// When [rememberMe] is null, retrieves the current setting from cache;
+  /// otherwise updates it. Returns the current or newly saved value,
+  /// defaulting to false on errors. This is the UI preference only —
+  /// whether a session survives a restart is decided by [restoreSession].
   @override
   Future<bool> rememberMe({bool? rememberMe}) async {
     try {
@@ -108,12 +109,23 @@ final class AuthenticationRepositoryImpl extends BaseRepository
   }
 
   @override
+  Future<Result<Unit, BusinessFailure>> restoreSession() async {
+    return asyncGuard(() async {
+      final remembered = local.get<bool>(CacheKey.isLoggedIn) ?? false;
+      if (!remembered) await tokens.clear();
+
+      return Unit.value;
+    });
+  }
+
+  @override
   Future<Result<Unit, BusinessFailure>> logout() async {
     return asyncGuard(() async {
-      // WHY: flag first, tokens second — if the second step fails, a
-      // cleared flag with orphaned tokens sends the user to the login
-      // screen (harmless); the reverse leaves a "signed in" flag with no
-      // tokens behind it.
+      // WHY: flag first, tokens second — the session derives from the
+      // stored tokens, so the token clear is the step that actually ends
+      // it. In this order a failed token clear leaves the user signed in
+      // with a surfaced error prompting a retry, instead of a cleared
+      // flag masking tokens that still authenticate.
       await local.remove([CacheKey.isLoggedIn, CacheKey.rememberMe]);
       await tokens.clear();
       return Unit.value;

--- a/lib/src/data/repositories/router_repository_impl.dart
+++ b/lib/src/data/repositories/router_repository_impl.dart
@@ -1,10 +1,12 @@
 import '../../domain/repositories/router_repository.dart';
 import '../services/cache/cache_service.dart';
+import '../services/network/auth/token_manager.dart';
 
 class RouterRepositoryImpl extends RouterRepository {
-  RouterRepositoryImpl({required this.cacheService});
+  RouterRepositoryImpl({required this.cacheService, required this.tokens});
 
   final CacheService cacheService;
+  final TokenManager tokens;
 
   @override
   bool isOnboardingCompleted() {
@@ -12,8 +14,10 @@ class RouterRepositoryImpl extends RouterRepository {
   }
 
   @override
-  bool isUserLoggedIn() {
-    return cacheService.get(CacheKey.isLoggedIn) ?? false;
+  Future<bool> hasSession() async {
+    final refreshToken = await tokens.refreshToken;
+
+    return refreshToken != null && refreshToken.isNotEmpty;
   }
 
   @override

--- a/lib/src/data/services/cache/cache_service.dart
+++ b/lib/src/data/services/cache/cache_service.dart
@@ -2,7 +2,19 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 part 'shared_preference_service.dart';
 
-enum CacheKey { isOnBoardingCompleted, isLoggedIn, rememberMe, language }
+enum CacheKey {
+  isOnBoardingCompleted,
+
+  /// Set at login only when the user asked to be remembered. Read at
+  /// startup by `restoreSession` to decide whether a previous run's
+  /// tokens survive. Not the session source of truth — the stored
+  /// refresh token is.
+  isLoggedIn,
+
+  /// The "Remember Me" checkbox preference, persisted for the UI.
+  rememberMe,
+  language,
+}
 
 abstract class CacheService {
   Future<void> save<T>(CacheKey key, T value);

--- a/lib/src/domain/repositories/authentication_repository.dart
+++ b/lib/src/domain/repositories/authentication_repository.dart
@@ -22,4 +22,10 @@ abstract interface class AuthenticationRepository {
   Future<String> resendOTP(Map<String, dynamic> data);
 
   Future<Result<Unit, BusinessFailure>> logout();
+
+  /// Called once at startup. Honors the remember-me choice recorded at
+  /// login: when the remembered-session flag (`CacheKey.isLoggedIn`) is
+  /// not set, any tokens left from a previous run are cleared so the
+  /// session does not silently survive a restart the user opted out of.
+  Future<Result<Unit, BusinessFailure>> restoreSession();
 }

--- a/lib/src/domain/repositories/router_repository.dart
+++ b/lib/src/domain/repositories/router_repository.dart
@@ -1,7 +1,9 @@
 abstract class RouterRepository {
   bool isOnboardingCompleted();
 
-  bool isUserLoggedIn();
+  /// Whether a session exists. Derived from the stored tokens — the
+  /// source of truth — not from a cached flag that can go stale.
+  Future<bool> hasSession();
 
   void saveOnboardingAsCompleted();
 }

--- a/lib/src/domain/use_cases/authentication_use_case.dart
+++ b/lib/src/domain/use_cases/authentication_use_case.dart
@@ -44,3 +44,13 @@ final class LogoutUseCase {
     return repository.logout();
   }
 }
+
+final class RestoreSessionUseCase {
+  RestoreSessionUseCase(this.repository);
+
+  final AuthenticationRepository repository;
+
+  Future<Result<Unit, BusinessFailure>> call() async {
+    return repository.restoreSession();
+  }
+}

--- a/lib/src/domain/use_cases/router_use_case.dart
+++ b/lib/src/domain/use_cases/router_use_case.dart
@@ -10,13 +10,13 @@ final class GetOnboardingStatusUseCase {
   }
 }
 
-final class GetUserLoginStatusUseCase {
-  GetUserLoginStatusUseCase(this.repository);
+final class GetSessionStatusUseCase {
+  GetSessionStatusUseCase(this.repository);
 
   final RouterRepository repository;
 
-  bool call() {
-    return repository.isUserLoggedIn();
+  Future<bool> call() {
+    return repository.hasSession();
   }
 }
 

--- a/lib/src/presentation/core/application_state/logout_provider/logout_provider.dart
+++ b/lib/src/presentation/core/application_state/logout_provider/logout_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../core/base/result.dart';
 import '../../../../core/di/dependency_injection.dart';
+import '../session_status_provider/session_status_provider.dart';
 
 part 'logout_provider.g.dart';
 
@@ -25,6 +26,9 @@ class Logout extends _$Logout {
     switch (result) {
       case Success():
         ref.read(resetRepositoryUseCaseProvider).call(ref);
+        // WHY: the session gate navigates, not the page. Refreshing the
+        // session status flips routerState to login.
+        ref.invalidate(sessionStatusProvider);
         state = const AsyncValue.data(true);
       case Error(:final error):
         state = AsyncValue.error(error, StackTrace.current);

--- a/lib/src/presentation/core/application_state/onboarding_status_provider/onboarding_status_provider.dart
+++ b/lib/src/presentation/core/application_state/onboarding_status_provider/onboarding_status_provider.dart
@@ -1,0 +1,14 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../core/di/dependency_injection.dart';
+
+part 'onboarding_status_provider.g.dart';
+
+/// Whether the user has completed onboarding. `routerState` watches this;
+/// the onboarding page invalidates it after marking completion, which is
+/// what moves the gate forward. Reading the cache is cheap, so the
+/// provider stays a thin reactive wrapper over the use case.
+@Riverpod(keepAlive: true)
+bool onboardingStatus(Ref ref) {
+  return ref.read(getOnboardingStatusUseCaseProvider).call();
+}

--- a/lib/src/presentation/core/application_state/session_status_provider/session_status_provider.dart
+++ b/lib/src/presentation/core/application_state/session_status_provider/session_status_provider.dart
@@ -1,0 +1,18 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../core/di/dependency_injection.dart';
+
+part 'session_status_provider.g.dart';
+
+enum SessionStatus { authenticated, unauthenticated }
+
+/// Whether a session exists, derived from the stored tokens — not from a
+/// cached boolean that can go stale. `routerState` watches this to pick
+/// the auth gate; login and logout invalidate it, which is what moves the
+/// user between the authenticated and unauthenticated areas.
+@Riverpod(keepAlive: true)
+Future<SessionStatus> sessionStatus(Ref ref) async {
+  final hasSession = await ref.read(getSessionStatusUseCaseProvider).call();
+
+  return hasSession ? .authenticated : .unauthenticated;
+}

--- a/lib/src/presentation/core/application_state/startup_provider/app_startup_provider.dart
+++ b/lib/src/presentation/core/application_state/startup_provider/app_startup_provider.dart
@@ -14,4 +14,10 @@ Future<void> appStartup(Ref ref) async {
   await ref.watch(sharedPreferencesProvider.future);
 
   await ref.read(localizationProvider.notifier).setCurrentLocal();
+
+  // WHY: honors "remember me" before the session gate first reads the
+  // tokens — a previous run's session must not survive a restart the
+  // user opted out of. The Result is intentionally unobserved: a failed
+  // cleanup is logged by the guard and must not block startup.
+  await ref.read(restoreSessionUseCaseProvider).call();
 }

--- a/lib/src/presentation/core/router/parts/authentication_routes.dart
+++ b/lib/src/presentation/core/router/parts/authentication_routes.dart
@@ -1,41 +1,43 @@
 part of '../router.dart';
 
+// WHY: route definitions are split per feature as parts of router.dart so
+// the route tree stays one navigable unit while each file stays small.
 List<GoRoute> _authenticationRoutes(Ref ref) {
   return [
     GoRoute(
-      path: Routes.login,
-      name: Routes.login,
+      path: Routes.login.path,
+      name: Routes.login.name,
       pageBuilder: (context, state) {
         return const MaterialPage(child: LoginPage());
       },
       routes: [
         GoRoute(
-          path: Routes.registration,
-          name: Routes.registration,
+          path: Routes.registration.path,
+          name: Routes.registration.name,
           pageBuilder: (context, state) =>
               const MaterialPage(child: RegistrationPage()),
         ),
         GoRoute(
-          path: Routes.resetPassword,
-          name: Routes.resetPassword,
+          path: Routes.resetPassword.path,
+          name: Routes.resetPassword.name,
           pageBuilder: (context, state) =>
               const MaterialPage(child: ResetPasswordPage()),
           routes: [
             GoRoute(
-              path: Routes.emailVerification,
-              name: Routes.emailVerification,
+              path: Routes.emailVerification.path,
+              name: Routes.emailVerification.name,
               pageBuilder: (context, state) =>
                   const MaterialPage(child: EmailVerificationPage()),
             ),
             GoRoute(
-              path: Routes.createNewPassword,
-              name: Routes.createNewPassword,
+              path: Routes.createNewPassword.path,
+              name: Routes.createNewPassword.name,
               pageBuilder: (context, state) =>
                   const MaterialPage(child: CreateNewPasswordPage()),
               routes: [
                 GoRoute(
-                  path: Routes.resetPasswordSuccess,
-                  name: Routes.resetPasswordSuccess,
+                  path: Routes.resetPasswordSuccess.path,
+                  name: Routes.resetPasswordSuccess.name,
                   pageBuilder: (context, state) =>
                       const MaterialPage(child: ResetPasswordSuccessPage()),
                 ),

--- a/lib/src/presentation/core/router/parts/on_boarding_routes.dart
+++ b/lib/src/presentation/core/router/parts/on_boarding_routes.dart
@@ -1,7 +1,5 @@
 part of '../router.dart';
 
-// WHY: route definitions are split per feature as parts of router.dart so
-// the route tree stays one navigable unit while each file stays small.
 List<GoRoute> _onboardingRoutes(Ref ref) {
   return [
     GoRoute(

--- a/lib/src/presentation/core/router/parts/on_boarding_routes.dart
+++ b/lib/src/presentation/core/router/parts/on_boarding_routes.dart
@@ -1,17 +1,24 @@
 part of '../router.dart';
 
+// WHY: route definitions are split per feature as parts of router.dart so
+// the route tree stays one navigable unit while each file stays small.
 List<GoRoute> _onboardingRoutes(Ref ref) {
   return [
     GoRoute(
-      path: Routes.splash,
-      name: Routes.splash,
+      path: Routes.splash.path,
+      name: Routes.splash.name,
       pageBuilder: (context, state) {
-        return const NoTransitionPage(child: SplashPage());
+        // WHY: the splash route hosts the startup widget so a failed
+        // startup shows its retry UI — the gate pins the user here while
+        // startup is loading or failed.
+        return const NoTransitionPage(
+          child: AppStartupWidget(loading: SplashPage(), loaded: SplashPage()),
+        );
       },
     ),
     GoRoute(
-      path: Routes.onboarding,
-      name: Routes.onboarding,
+      path: Routes.onboarding.path,
+      name: Routes.onboarding.name,
       pageBuilder: (context, state) {
         return const MaterialPage(child: OnboardingPage());
       },

--- a/lib/src/presentation/core/router/parts/shell_routes.dart
+++ b/lib/src/presentation/core/router/parts/shell_routes.dart
@@ -1,7 +1,5 @@
 part of '../router.dart';
 
-// WHY: route definitions are split per feature as parts of router.dart so
-// the route tree stays one navigable unit while each file stays small.
 StatefulShellRoute _shellRoutes(Ref ref) {
   return StatefulShellRoute.indexedStack(
     builder: (context, state, navigationShell) {

--- a/lib/src/presentation/core/router/parts/shell_routes.dart
+++ b/lib/src/presentation/core/router/parts/shell_routes.dart
@@ -1,5 +1,7 @@
 part of '../router.dart';
 
+// WHY: route definitions are split per feature as parts of router.dart so
+// the route tree stays one navigable unit while each file stays small.
 StatefulShellRoute _shellRoutes(Ref ref) {
   return StatefulShellRoute.indexedStack(
     builder: (context, state, navigationShell) {
@@ -9,8 +11,8 @@ StatefulShellRoute _shellRoutes(Ref ref) {
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: Routes.home,
-            name: Routes.home,
+            path: Routes.home.path,
+            name: Routes.home.name,
             pageBuilder: (context, state) {
               return const MaterialPage(child: HomePage());
             },
@@ -20,8 +22,8 @@ StatefulShellRoute _shellRoutes(Ref ref) {
       StatefulShellBranch(
         routes: [
           GoRoute(
-            path: Routes.profile,
-            name: Routes.profile,
+            path: Routes.profile.path,
+            name: Routes.profile.name,
             pageBuilder: (context, state) {
               return const MaterialPage(child: ProfilePage());
             },

--- a/lib/src/presentation/core/router/redirect_gate.dart
+++ b/lib/src/presentation/core/router/redirect_gate.dart
@@ -1,0 +1,37 @@
+import 'routes.dart';
+
+/// The router's gating policy. Pure — no `Ref`, no `BuildContext` — so
+/// the whole policy is unit-testable in isolation.
+abstract final class RedirectGate {
+  /// Enforces the [gate] destination for [path], or returns `null` to
+  /// allow it.
+  ///
+  /// Splash and onboarding are hard gates (the user is pinned there). The
+  /// login gate allows the whole auth flow. For any other gate — in
+  /// practice [Routes.home], the authenticated state — only the
+  /// gate-only routes redirect, so ordinary in-app navigation is
+  /// unaffected. Idempotent — never returns the path already being
+  /// visited, which is what prevents redirect loops.
+  static String? redirect(String path, Routes gate) {
+    return switch (gate) {
+      .splash => path == Routes.splash.path ? null : Routes.splash.path,
+      .onboarding =>
+        path == Routes.onboarding.path ? null : Routes.onboarding.path,
+      .login => _isAuthFlowPath(path) ? null : Routes.login.path,
+      _ => _isGateOnlyPath(path) ? Routes.home.path : null,
+    };
+  }
+
+  /// The unauthenticated auth flow: `/login` and everything nested under
+  /// it (registration, the reset-password chain).
+  static bool _isAuthFlowPath(String path) =>
+      path == Routes.login.path || path.startsWith('${Routes.login.path}/');
+
+  /// Routes that only exist to serve a gate. An authenticated user
+  /// visiting one of these (or the bare `/`) is sent home.
+  static bool _isGateOnlyPath(String path) =>
+      _isAuthFlowPath(path) ||
+      path == Routes.splash.path ||
+      path == Routes.onboarding.path ||
+      path == '/';
+}

--- a/lib/src/presentation/core/router/router.dart
+++ b/lib/src/presentation/core/router/router.dart
@@ -3,7 +3,6 @@ import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/extensions/riverpod_extensions.dart';
-import '../../../core/logger/log.dart';
 import '../../features/authentication/forgot_password/view/create_new_password_page.dart';
 import '../../features/authentication/forgot_password/view/email_verification_page.dart';
 import '../../features/authentication/forgot_password/view/reset_password_page.dart';
@@ -16,6 +15,8 @@ import '../../features/profile/view/profile_page.dart';
 import '../../features/splash/view/splash_page.dart';
 import '../widgets/app_startup/startup_widget.dart';
 import '../widgets/navigation_shell.dart';
+import '../widgets/not_found_screen.dart';
+import 'redirect_gate.dart';
 import 'router_state/router_state_provider.dart';
 import 'routes.dart';
 
@@ -28,35 +29,20 @@ final _rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'Root');
 
 @Riverpod(keepAlive: true)
 GoRouter goRouter(Ref ref) {
+  // WHY: created once — calling `asListenable` inside `redirect` would
+  // allocate a fresh subscription per navigation that nothing disposes on
+  // this keepAlive provider.
+  final refresh = ref.asListenable(routerStateProvider);
+
   return GoRouter(
     navigatorKey: _rootNavigatorKey,
     debugLogDiagnostics: true,
-    refreshListenable: ref.asListenable(routerStateProvider),
-    initialLocation: Routes.initial,
-    redirect: (context, state) {
-      Log.info('Redirecting to ${state.uri}');
-      if ([
-        Routes.initial,
-        Routes.onboarding,
-        Routes.splash,
-      ].contains(state.uri.path)) {
-        return ref.asListenable(routerStateProvider).value;
-      }
-      return null;
-    },
+    refreshListenable: refresh,
+    initialLocation: Routes.splash.path,
+    redirect: (context, state) =>
+        RedirectGate.redirect(state.uri.path, ref.read(routerStateProvider)),
+    errorBuilder: (context, state) => NotFoundScreen(uri: state.uri),
     routes: [
-      GoRoute(
-        path: Routes.initial,
-        name: Routes.initial,
-        pageBuilder: (context, state) {
-          return const NoTransitionPage(
-            child: AppStartupWidget(
-              loading: SplashPage(),
-              loaded: SplashPage(),
-            ),
-          );
-        },
-      ),
       ..._onboardingRoutes(ref),
       ..._authenticationRoutes(ref),
       _shellRoutes(ref),

--- a/lib/src/presentation/core/router/router_state/router_state_provider.dart
+++ b/lib/src/presentation/core/router/router_state/router_state_provider.dart
@@ -1,42 +1,35 @@
-import 'dart:async';
-
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../../core/di/dependency_injection.dart';
+import '../../application_state/onboarding_status_provider/onboarding_status_provider.dart';
+import '../../application_state/session_status_provider/session_status_provider.dart';
 import '../../application_state/startup_provider/app_startup_provider.dart';
 import '../routes.dart';
 
 part 'router_state_provider.g.dart';
 
+/// The gate destination the router enforces, derived from app startup,
+/// onboarding, and session status.
+///
+/// The router reacts to this alone — it never reads startup or session
+/// directly, and never sees a token. Splash while startup (or the session
+/// read) is pending or failed; onboarding until completed; then home or
+/// login by session. New inputs (a force-update flag, a maintenance mode)
+/// compose here without touching the router.
+///
+/// A pure derivation on purpose: no timers, no side effects, no
+/// imperative transitions. The pages that change the underlying state
+/// (login, logout, onboarding completion) invalidate the providers this
+/// one watches, and the gate follows.
 @Riverpod(keepAlive: true)
-class RouterState extends _$RouterState {
-  @override
-  String? build() {
-    ref.listen(appStartupProvider, (_, state) {
-      if (!(state.isLoading || state.hasError)) {
-        decideNextRoute();
-      }
-    });
-    return Routes.initial;
-  }
+Routes routerState(Ref ref) {
+  final startup = ref.watch(appStartupProvider);
+  if (startup.isLoading || startup.hasError) return .splash;
 
-  void decideNextRoute() {
-    final isOnboarded = ref.read(getOnboardingStatusUseCaseProvider).call();
-    final isLoggedIn = ref.read(getUserLoginStatusUseCaseProvider).call();
+  if (!ref.watch(onboardingStatusProvider)) return .onboarding;
 
-    if (state == Routes.initial) {
-      state = Routes.splash;
-      Timer(const Duration(milliseconds: 500), () => decideNextRoute());
-      return;
-    }
-
-    if (!isOnboarded) {
-      state = Routes.onboarding;
-      // Mark onboarding as completed
-      ref.read(markOnboardingCompletedUseCaseProvider).call();
-      return;
-    }
-
-    state = isLoggedIn ? Routes.home : Routes.login;
-  }
+  return switch (ref.watch(sessionStatusProvider)) {
+    AsyncData(value: .authenticated) => .home,
+    AsyncData() => .login,
+    _ => .splash,
+  };
 }

--- a/lib/src/presentation/core/router/routes.dart
+++ b/lib/src/presentation/core/router/routes.dart
@@ -1,15 +1,27 @@
-class Routes {
-  static const String initial = '/';
-  static const String splash = '/splash';
-  static const String onboarding = '/onboarding';
+/// The app's named routes. [path] is the URL segment handed to
+/// `GoRoute.path`; `name` (the enum member name) is what `GoRoute.name`
+/// and named navigation (`context.pushNamed`) use. Keeping both on one
+/// enum means path and name cannot drift, and switches over routes are
+/// exhaustive.
+///
+/// Top-level routes carry absolute paths (leading `/`). Sub-routes carry
+/// relative segments and nest under their parent in the route tree — their
+/// full location is the joined path (e.g. `/login/registration`).
+enum Routes {
+  splash('/splash'),
+  onboarding('/onboarding'),
 
-  static const String login = '/login';
-  static const String resetPassword = 'reset-password';
-  static const String emailVerification = 'email-verification';
-  static const String createNewPassword = 'create-new-password';
-  static const String resetPasswordSuccess = 'reset-password-success';
-  static const String registration = 'registration';
+  login('/login'),
+  registration('registration'),
+  resetPassword('reset-password'),
+  emailVerification('email-verification'),
+  createNewPassword('create-new-password'),
+  resetPasswordSuccess('reset-password-success'),
 
-  static const String home = '/home';
-  static const String profile = '/profile';
+  home('/home'),
+  profile('/profile');
+
+  const Routes(this.path);
+
+  final String path;
 }

--- a/lib/src/presentation/core/widgets/not_found_screen.dart
+++ b/lib/src/presentation/core/widgets/not_found_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/extensions/app_localization.dart';
+import '../router/routes.dart';
+import '../theme/theme.dart';
+
+/// `errorBuilder` destination for unmatched routes. The button targets
+/// [Routes.home]; an unauthenticated user is redirected to login by the
+/// gate.
+class NotFoundScreen extends StatelessWidget {
+  const NotFoundScreen({required this.uri, super.key});
+
+  final Uri uri;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: context.spacing.s44,
+              color: context.color.text.secondary,
+            ),
+            Gap(context.spacing.s8),
+            Text(context.locale.noRouteFor(uri.toString())),
+            Gap(context.spacing.s24),
+            FilledButton(
+              onPressed: () => context.go(Routes.home.path),
+              child: Text(context.locale.goHome),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/create_new_password_page.dart
@@ -27,7 +27,9 @@ class CreateNewPasswordPage extends StatelessWidget {
               Gap(context.spacing.s32),
               FilledButton(
                 onPressed: () {
-                  context.pushReplacementNamed(Routes.resetPasswordSuccess);
+                  context.pushReplacementNamed(
+                    Routes.resetPasswordSuccess.name,
+                  );
                 },
                 child: Text(context.locale.resetPassword),
               ),

--- a/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/email_verification_page.dart
@@ -43,7 +43,7 @@ class EmailVerificationPage extends StatelessWidget {
                   text: context.locale.didNotReceiveEmail,
                   linkText: context.locale.tryAnotherEmail,
                   onTap: () {
-                    context.pushReplacementNamed(Routes.resetPassword);
+                    context.pushReplacementNamed(Routes.resetPassword.name);
                   },
                 ),
               ],
@@ -86,7 +86,7 @@ class _OTPFieldState extends State<_OTPField> {
                   if (index == 3 && value.length == 1) {
                     FocusScope.of(context).unfocus();
                     //TODO: Callback function
-                    context.pushReplacementNamed(Routes.createNewPassword);
+                    context.pushReplacementNamed(Routes.createNewPassword.name);
                   } else if (value.length == 1) {
                     FocusScope.of(context).nextFocus();
                   }

--- a/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
+++ b/lib/src/presentation/features/authentication/forgot_password/view/reset_password_page.dart
@@ -31,7 +31,7 @@ class ResetPasswordPage extends StatelessWidget {
               Gap(context.spacing.s16),
               FilledButton(
                 onPressed: () {
-                  context.pushReplacementNamed(Routes.emailVerification);
+                  context.pushReplacementNamed(Routes.emailVerification.name);
                 },
                 child: Text(context.locale.continueAction),
               ),

--- a/lib/src/presentation/features/authentication/login/riverpod/login_provider.dart
+++ b/lib/src/presentation/features/authentication/login/riverpod/login_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../../core/base/result.dart';
 import '../../../../../core/di/dependency_injection.dart';
+import '../../../../core/application_state/session_status_provider/session_status_provider.dart';
 
 part 'login_provider.g.dart';
 
@@ -29,5 +30,11 @@ class Login extends _$Login {
       Success() => AsyncValue.data(result),
       Error(:final error) => AsyncValue.error(error, StackTrace.current),
     };
+
+    // WHY: the session gate navigates, not the page. Refreshing the
+    // session status flips routerState to home, and the router redirects.
+    if (state.hasValue && state.value != null) {
+      ref.invalidate(sessionStatusProvider);
+    }
   }
 }

--- a/lib/src/presentation/features/authentication/login/view/login_page.dart
+++ b/lib/src/presentation/features/authentication/login/view/login_page.dart
@@ -34,10 +34,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   void initState() {
     super.initState();
 
+    // WHY: no navigation here — a successful login refreshes the session
+    // status and the router's gate moves the user to home.
     ref.listenManual(loginProvider, (previous, next) {
       switch (next) {
-        case AsyncData(:final value) when value != null:
-          context.pushReplacementNamed(Routes.home);
         case AsyncError(error: final BusinessFailure failure):
           ScaffoldMessenger.of(
             context,
@@ -110,7 +110,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                 text: context.locale.dontHaveAccount,
                 linkText: context.locale.signUp,
                 onTap: () {
-                  context.pushNamed(Routes.registration);
+                  context.pushNamed(Routes.registration.name);
                 },
               ),
             ],

--- a/lib/src/presentation/features/authentication/login/widgets/login_form_footer.dart
+++ b/lib/src/presentation/features/authentication/login/widgets/login_form_footer.dart
@@ -10,7 +10,7 @@ class _FormFooter extends ConsumerWidget {
   }
 
   void _navigateToResetPassword(BuildContext context) {
-    context.pushNamed(Routes.resetPassword);
+    context.pushNamed(Routes.resetPassword.name);
   }
 
   @override

--- a/lib/src/presentation/features/authentication/registration/view/registration_page.dart
+++ b/lib/src/presentation/features/authentication/registration/view/registration_page.dart
@@ -127,7 +127,7 @@ class _RegistrationPageState extends State<RegistrationPage> {
                 text: context.locale.alreadyHaveAccount,
                 linkText: context.locale.signIn,
                 onTap: () {
-                  context.pushNamedAndRemoveUntil(Routes.login);
+                  context.pushNamedAndRemoveUntil(Routes.login.name);
                 },
               ),
             ],

--- a/lib/src/presentation/features/home/view/home_page.dart
+++ b/lib/src/presentation/features/home/view/home_page.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../../core/extensions/app_localization.dart';
 import '../../../../domain/failures/business_failure.dart';
 import '../../../core/application_state/logout_provider/logout_provider.dart';
-import '../../../core/router/routes.dart';
 import '../../../core/theme/theme.dart';
 import '../../../core/widgets/loading_indicator.dart';
 
@@ -21,10 +19,10 @@ class _HomePageState extends ConsumerState<HomePage> {
   @override
   void initState() {
     super.initState();
+    // WHY: no navigation here — logout refreshes the session status and
+    // the router's gate moves the user to login.
     ref.listenManual(logoutProvider, (previous, next) {
       switch (next) {
-        case AsyncData(:final value) when value == true:
-          context.pushReplacementNamed(Routes.login);
         case AsyncError(error: final BusinessFailure failure):
           ScaffoldMessenger.of(
             context,

--- a/lib/src/presentation/features/onboarding/view/onboarding_page.dart
+++ b/lib/src/presentation/features/onboarding/view/onboarding_page.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../core/di/dependency_injection.dart';
 import '../../../../core/extensions/app_localization.dart';
-import '../../../core/router/routes.dart';
+import '../../../core/application_state/onboarding_status_provider/onboarding_status_provider.dart';
 import '../../../core/theme/theme.dart';
 import '../../../core/widgets/text/typography.dart';
 
@@ -26,6 +26,13 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage>
   void initState() {
     super.initState();
     _pageController = PageController();
+  }
+
+  void _onGetStarted() {
+    ref.read(markOnboardingCompletedUseCaseProvider).call();
+    // WHY: the gate navigates, not the page — refreshing the onboarding
+    // status flips routerState past onboarding to login or home.
+    ref.invalidate(onboardingStatusProvider);
   }
 
   @override
@@ -103,9 +110,7 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage>
                     horizontal: context.padding.p24,
                   ),
                   child: FilledButton(
-                    onPressed: () {
-                      context.goNamed(Routes.login);
-                    },
+                    onPressed: _onGetStarted,
                     child: Text(context.locale.getStarted),
                   ),
                 ),

--- a/test/data/repositories/router_repository_impl_test.dart
+++ b/test/data/repositories/router_repository_impl_test.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_template/src/data/repositories/router_repository_impl.dart';
+import 'package:flutter_template/src/data/services/cache/cache_service.dart';
+import 'package:flutter_template/src/data/services/network/auth/token_manager.dart';
+import 'package:flutter_template/src/data/services/network/auth/token_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../services/network/helpers.dart';
+
+class _FakeCacheService implements CacheService {
+  final Map<CacheKey, Object?> _data = {};
+
+  @override
+  Future<void> save<T>(CacheKey key, T value) async {
+    _data[key] = value;
+  }
+
+  @override
+  T? get<T>(CacheKey key) => _data[key] as T?;
+
+  @override
+  Future<void> remove(List<CacheKey> keys) async {
+    keys.forEach(_data.remove);
+  }
+
+  @override
+  Future<void> clear() async {
+    _data.clear();
+  }
+}
+
+void main() {
+  RouterRepositoryImpl repoWith({Map<TokenKey, String>? tokens}) {
+    return RouterRepositoryImpl(
+      cacheService: _FakeCacheService(),
+      tokens: TokenManager(
+        store: FakeTokenStore(initial: tokens),
+        transport: Dio(),
+        refreshEndpoint: testRefreshPath,
+      ),
+    );
+  }
+
+  group('RouterRepositoryImpl.hasSession', () {
+    test('true when a refresh token is stored', () async {
+      final repo = repoWith(tokens: {TokenKey.refresh: 'r.tok'});
+
+      expect(await repo.hasSession(), isTrue);
+    });
+
+    test('false when no tokens are stored', () async {
+      expect(await repoWith().hasSession(), isFalse);
+    });
+
+    test('false when the stored refresh token is empty', () async {
+      final repo = repoWith(tokens: {TokenKey.refresh: ''});
+
+      expect(await repo.hasSession(), isFalse);
+    });
+  });
+
+  group('RouterRepositoryImpl onboarding', () {
+    test('round-trips the completion flag', () {
+      final repo = repoWith();
+
+      expect(repo.isOnboardingCompleted(), isFalse);
+      repo.saveOnboardingAsCompleted();
+      expect(repo.isOnboardingCompleted(), isTrue);
+    });
+  });
+}

--- a/test/presentation/core/router/redirect_gate_test.dart
+++ b/test/presentation/core/router/redirect_gate_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_template/src/presentation/core/router/redirect_gate.dart';
+import 'package:flutter_template/src/presentation/core/router/routes.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RedirectGate', () {
+    group('splash gate (startup pending or failed)', () {
+      test('pins every path to splash', () {
+        expect(RedirectGate.redirect('/', Routes.splash), '/splash');
+        expect(RedirectGate.redirect('/home', Routes.splash), '/splash');
+        expect(RedirectGate.redirect('/login', Routes.splash), '/splash');
+        expect(RedirectGate.redirect('/unknown', Routes.splash), '/splash');
+      });
+
+      test('is idempotent at splash', () {
+        expect(RedirectGate.redirect('/splash', Routes.splash), isNull);
+      });
+    });
+
+    group('onboarding gate', () {
+      test('pins every path to onboarding', () {
+        expect(
+          RedirectGate.redirect('/home', Routes.onboarding),
+          '/onboarding',
+        );
+        expect(
+          RedirectGate.redirect('/login', Routes.onboarding),
+          '/onboarding',
+        );
+      });
+
+      test('is idempotent at onboarding', () {
+        expect(RedirectGate.redirect('/onboarding', Routes.onboarding), isNull);
+      });
+    });
+
+    group('login gate (unauthenticated)', () {
+      test('allows the whole auth flow', () {
+        expect(RedirectGate.redirect('/login', Routes.login), isNull);
+        expect(
+          RedirectGate.redirect('/login/registration', Routes.login),
+          isNull,
+        );
+        expect(
+          RedirectGate.redirect(
+            '/login/reset-password/create-new-password',
+            Routes.login,
+          ),
+          isNull,
+        );
+      });
+
+      test('sends everything else to login', () {
+        expect(RedirectGate.redirect('/home', Routes.login), '/login');
+        expect(RedirectGate.redirect('/profile', Routes.login), '/login');
+        expect(RedirectGate.redirect('/splash', Routes.login), '/login');
+        expect(RedirectGate.redirect('/', Routes.login), '/login');
+      });
+    });
+
+    group('home gate (authenticated)', () {
+      test('keeps in-app navigation free', () {
+        expect(RedirectGate.redirect('/home', Routes.home), isNull);
+        expect(RedirectGate.redirect('/profile', Routes.home), isNull);
+        // Unknown paths fall through to the router's errorBuilder.
+        expect(RedirectGate.redirect('/unknown', Routes.home), isNull);
+      });
+
+      test('bounces gate-only routes home', () {
+        expect(RedirectGate.redirect('/login', Routes.home), '/home');
+        expect(
+          RedirectGate.redirect('/login/registration', Routes.home),
+          '/home',
+        );
+        expect(RedirectGate.redirect('/splash', Routes.home), '/home');
+        expect(RedirectGate.redirect('/onboarding', Routes.home), '/home');
+        expect(RedirectGate.redirect('/', Routes.home), '/home');
+      });
+    });
+  });
+}

--- a/test/presentation/core/router/router_state_test.dart
+++ b/test/presentation/core/router/router_state_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_template/src/presentation/core/application_state/onboarding_status_provider/onboarding_status_provider.dart';
+import 'package:flutter_template/src/presentation/core/application_state/session_status_provider/session_status_provider.dart';
+import 'package:flutter_template/src/presentation/core/application_state/startup_provider/app_startup_provider.dart';
+import 'package:flutter_template/src/presentation/core/router/router_state/router_state_provider.dart';
+import 'package:flutter_template/src/presentation/core/router/routes.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  ProviderContainer containerWith({
+    required Future<void> Function(Ref ref) startup,
+    bool onboarded = true,
+    Future<SessionStatus> Function(Ref ref)? session,
+  }) {
+    final container = ProviderContainer(
+      // WHY: matches the app's ProviderScope — auto-retry disabled so a
+      // failed startup settles into its error state instead of silently
+      // retrying past the assertion.
+      retry: (retryCount, error) => null,
+      overrides: [
+        appStartupProvider.overrideWith(startup),
+        onboardingStatusProvider.overrideWith((ref) => onboarded),
+        if (session != null) sessionStatusProvider.overrideWith(session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    return container;
+  }
+
+  Future<void> startupDone(Ref ref) async {}
+
+  group('routerState', () {
+    test('splash while startup is loading', () {
+      final container = containerWith(
+        startup: (ref) => Completer<void>().future,
+      );
+
+      expect(container.read(routerStateProvider), Routes.splash);
+    });
+
+    test('splash when startup failed', () async {
+      final container = containerWith(
+        startup: (ref) async => throw Exception('startup failed'),
+      );
+      await expectLater(
+        container.read(appStartupProvider.future),
+        throwsException,
+      );
+
+      expect(container.read(routerStateProvider), Routes.splash);
+    });
+
+    test('onboarding before it is completed', () async {
+      final container = containerWith(startup: startupDone, onboarded: false);
+      await container.read(appStartupProvider.future);
+
+      expect(container.read(routerStateProvider), Routes.onboarding);
+    });
+
+    test('splash while the session status is loading', () async {
+      final container = containerWith(
+        startup: startupDone,
+        session: (ref) => Completer<SessionStatus>().future,
+      );
+      await container.read(appStartupProvider.future);
+
+      expect(container.read(routerStateProvider), Routes.splash);
+    });
+
+    test('login when unauthenticated', () async {
+      final container = containerWith(
+        startup: startupDone,
+        session: (ref) async => SessionStatus.unauthenticated,
+      );
+      await container.read(appStartupProvider.future);
+      await container.read(sessionStatusProvider.future);
+
+      expect(container.read(routerStateProvider), Routes.login);
+    });
+
+    test('home when authenticated', () async {
+      final container = containerWith(
+        startup: startupDone,
+        session: (ref) async => SessionStatus.authenticated,
+      );
+      await container.read(appStartupProvider.future);
+      await container.read(sessionStatusProvider.future);
+
+      expect(container.read(routerStateProvider), Routes.home);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #54 — review after it merges, or review only the top commit. Independent of #55; whichever merges second reconciles a small `main.dart` conflict (the `retry:` setting moves into `bootstrap()`).

## What this fixes

Four shipped bugs:

- **Auth-gate holes** — `/home` and `/profile` were reachable while logged out, `/login` while authenticated. The gate now covers every route.
- **A subscription leak** — the redirect callback allocated a fresh listenable per navigation on a `keepAlive` provider. It is created once now.
- **Premature onboarding completion** — the old router state marked onboarding completed while *deciding to show it*. The page now marks completion when the user finishes.
- **Stale login flag on cold start** — session status derives from the stored refresh token, not a cached boolean that could outlive the tokens.

## The design

- `Routes` is an enum carrying its path; `GoRoute.path`/`.name` and every navigation call read the same member, so the two cannot drift.
- `RedirectGate.redirect(path, gate)` is the entire gating policy: pure, class-scoped, idempotent (the redirect-loop guard), unit-tested as a matrix.
- `routerStateProvider` is a pure derivation over startup, onboarding, and session status — no timers, no side effects. New gating inputs (force-update, maintenance) compose there; the router never changes.
- Navigation on auth changes is gate-driven: login, logout, and onboarding completion invalidate their status provider and the gate follows. Pages no longer push routes imperatively for these transitions.
- `restoreSession()` at startup honors "remember me": without the flag, a previous run's tokens are cleared.
- Unmatched routes land on a localized `NotFoundScreen` via `errorBuilder`.
- Riverpod's default provider auto-retry is disabled at the root scope — the gate's splash-with-retry contract needs failures to settle, not silently retry.

## Docs and tests

`docs/router.md` documents the invalidate-to-navigate rule, the gate matrix, the derivation order, and the route-adding recipe; README and `architecture.md` point at it. 18 new tests: the full gate matrix, all six derivation states, and the token-aware session checks (103 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added startup session restoration that respects “Remember me” preferences.
  - Improved routing across startup, onboarding, authentication, and signed-in screens.
  - Added a localized not-found screen with a direct return-home action.
  - Added Arabic and Bengali translations for new routing messages.

- **Bug Fixes**
  - Sign-in, sign-out, and onboarding transitions now update automatically without manual navigation.
  - Unmatched routes now display a helpful error instead of failing silently.

- **Documentation**
  - Expanded guidance for session handling, routing behavior, and route registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->