### PR TITLE
Align the auth models with the mapper convention

### DIFF
--- a/lib/src/data/mappers/login_mapper.dart
+++ b/lib/src/data/mappers/login_mapper.dart
@@ -1,0 +1,32 @@
+import '../../domain/entities/login_entity.dart';
+import '../models/login_model.dart';
+
+/// Crosses the model ↔ entity seam for the login flow. Formatting
+/// (trimming, date parsing) belongs here, so entities receive finished
+/// values and models stay wire-shaped.
+///
+/// The response mapping deliberately drops the tokens: the repository
+/// persists them through `TokenManager`, and they never cross into the
+/// domain layer.
+class LoginMapper {
+  const LoginMapper();
+
+  LoginResponseEntity toEntity(LoginResponseModel model) {
+    return LoginResponseEntity(
+      id: model.id,
+      username: model.username,
+      email: model.email,
+      firstName: model.firstName,
+      lastName: model.lastName,
+      gender: model.gender,
+      image: model.image,
+    );
+  }
+
+  LoginRequestModel toRequestModel(LoginRequestEntity entity) {
+    return LoginRequestModel(
+      username: entity.username,
+      password: entity.password,
+    );
+  }
+}

--- a/lib/src/data/mappers/sign_up_mapper.dart
+++ b/lib/src/data/mappers/sign_up_mapper.dart
@@ -1,0 +1,20 @@
+import '../../domain/entities/sign_up_entity.dart';
+import '../models/sign_up_model.dart';
+
+/// Crosses the model ↔ entity seam for the sign-up flow.
+class SignUpMapper {
+  const SignUpMapper();
+
+  SignUpResponseEntity toEntity(SignUpResponseModel model) {
+    return SignUpResponseEntity(accessToken: model.accessToken);
+  }
+
+  SignUpRequestModel toRequestModel(SignUpRequestEntity entity) {
+    return SignUpRequestModel(
+      firstName: entity.firstName,
+      lastName: entity.lastName,
+      email: entity.email,
+      password: entity.password,
+    );
+  }
+}

--- a/lib/src/data/models/login_model.dart
+++ b/lib/src/data/models/login_model.dart
@@ -1,21 +1,18 @@
 import 'package:dart_mappable/dart_mappable.dart';
 
-import '../../domain/entities/login_entity.dart';
-
 part 'login_model.mapper.dart';
 
 @MappableClass(generateMethods: GenerateMethods.decode)
-class LoginResponseModel extends LoginResponseEntity
-    with LoginResponseModelMappable {
+class LoginResponseModel with LoginResponseModelMappable {
   LoginResponseModel({
     required this.id,
     required this.username,
     required this.email,
     required this.firstName,
     required this.lastName,
-    required this.image,
-    required super.accessToken,
     required this.gender,
+    required this.image,
+    required this.accessToken,
     required this.refreshToken,
   });
 
@@ -26,20 +23,16 @@ class LoginResponseModel extends LoginResponseEntity
   final String lastName;
   final String gender;
   final String image;
+  final String accessToken;
   final String refreshToken;
 
   static const fromJson = LoginResponseModelMapper.fromJson;
 }
 
-@MappableClass(generateMethods: GenerateMethods.copy | GenerateMethods.encode)
-class LoginRequestModel extends LoginRequestEntity
-    with LoginRequestModelMappable {
-  LoginRequestModel({required super.username, required super.password});
+@MappableClass(generateMethods: GenerateMethods.encode)
+class LoginRequestModel with LoginRequestModelMappable {
+  LoginRequestModel({required this.username, required this.password});
 
-  factory LoginRequestModel.fromEntity(LoginRequestEntity entity) {
-    return LoginRequestModel(
-      username: entity.username,
-      password: entity.password,
-    );
-  }
+  final String username;
+  final String password;
 }

--- a/lib/src/data/models/sign_up_model.dart
+++ b/lib/src/data/models/sign_up_model.dart
@@ -1,20 +1,32 @@
-import '../../domain/entities/sign_up_entity.dart';
+import 'package:dart_mappable/dart_mappable.dart';
 
-extension SignUpRequestModel on SignUpRequestEntity {
-  Map<String, dynamic> toJson() {
-    return {
-      'first_name': firstName,
-      'last_name': lastName,
-      'email': email,
-      'password': password,
-    };
-  }
+part 'sign_up_model.mapper.dart';
+
+@MappableClass(generateMethods: GenerateMethods.encode)
+class SignUpRequestModel with SignUpRequestModelMappable {
+  SignUpRequestModel({
+    required this.firstName,
+    required this.lastName,
+    required this.email,
+    required this.password,
+  });
+
+  @MappableField(key: 'first_name')
+  final String firstName;
+
+  @MappableField(key: 'last_name')
+  final String lastName;
+
+  final String email;
+  final String password;
 }
 
-class SignUpResponseModel extends SignUpResponseEntity {
-  SignUpResponseModel({required super.accessToken});
+@MappableClass(generateMethods: GenerateMethods.decode)
+class SignUpResponseModel with SignUpResponseModelMappable {
+  SignUpResponseModel({required this.accessToken});
 
-  factory SignUpResponseModel.fromJson(Map<String, dynamic> json) {
-    return SignUpResponseModel(accessToken: json['access_token']);
-  }
+  @MappableField(key: 'access_token')
+  final String accessToken;
+
+  static const fromJson = SignUpResponseModelMapper.fromJson;
 }

--- a/lib/src/data/repositories/authentication_repository_impl.dart
+++ b/lib/src/data/repositories/authentication_repository_impl.dart
@@ -5,6 +5,7 @@ import '../../domain/entities/sign_up_entity.dart';
 import '../../domain/failures/business_failure.dart';
 import '../../domain/repositories/authentication_repository.dart';
 import '../base/base_repository.dart';
+import '../mappers/login_mapper.dart';
 import '../models/login_model.dart';
 import '../services/cache/cache_service.dart';
 import '../services/network/auth/token_manager.dart';
@@ -23,6 +24,8 @@ final class AuthenticationRepositoryImpl extends BaseRepository
   final CacheService local;
   final TokenManager tokens;
 
+  static const _loginMapper = LoginMapper();
+
   @override
   Future<SignUpResponseEntity> register(SignUpRequestEntity data) async {
     // TODO: implement register
@@ -34,7 +37,7 @@ final class AuthenticationRepositoryImpl extends BaseRepository
     LoginRequestEntity data,
   ) async {
     return asyncGuard(() async {
-      final request = LoginRequestModel.fromEntity(data);
+      final request = _loginMapper.toRequestModel(data);
       final response = await remote.login(request.toJson());
 
       final model = LoginResponseModel.fromJson(response.data);
@@ -44,7 +47,7 @@ final class AuthenticationRepositoryImpl extends BaseRepository
         refresh: model.refreshToken,
       );
 
-      if (data.shouldRemeber ?? false) {
+      if (data.shouldRemember ?? false) {
         try {
           await _saveSession();
         } catch (_) {
@@ -55,7 +58,7 @@ final class AuthenticationRepositoryImpl extends BaseRepository
         }
       }
 
-      return model;
+      return _loginMapper.toEntity(model);
     });
   }
 

--- a/lib/src/domain/entities/login_entity.dart
+++ b/lib/src/domain/entities/login_entity.dart
@@ -1,19 +1,35 @@
-interface class LoginEntity {}
-
-class LoginRequestEntity extends LoginEntity {
+class LoginRequestEntity {
   LoginRequestEntity({
     required this.username,
     required this.password,
-    this.shouldRemeber = false,
+    this.shouldRemember = false,
   });
 
   final String username;
   final String password;
-  final bool? shouldRemeber;
+  final bool? shouldRemember;
 }
 
-class LoginResponseEntity extends LoginEntity {
-  LoginResponseEntity({required this.accessToken});
+/// The signed-in user, as the domain sees it. Tokens never appear here:
+/// the data layer persists them through `TokenManager`, and the app
+/// reasons about the session through the session gate — never through
+/// token values.
+class LoginResponseEntity {
+  LoginResponseEntity({
+    required this.id,
+    required this.username,
+    required this.email,
+    required this.firstName,
+    required this.lastName,
+    required this.gender,
+    required this.image,
+  });
 
-  final String accessToken;
+  final int id;
+  final String username;
+  final String email;
+  final String firstName;
+  final String lastName;
+  final String gender;
+  final String image;
 }

--- a/lib/src/domain/entities/sign_up_entity.dart
+++ b/lib/src/domain/entities/sign_up_entity.dart
@@ -1,6 +1,4 @@
-interface class SignUpEntity {}
-
-class SignUpRequestEntity extends SignUpEntity {
+class SignUpRequestEntity {
   SignUpRequestEntity({
     required this.firstName,
     required this.lastName,
@@ -14,7 +12,7 @@ class SignUpRequestEntity extends SignUpEntity {
   final String password;
 }
 
-class SignUpResponseEntity extends SignUpEntity {
+class SignUpResponseEntity {
   SignUpResponseEntity({required this.accessToken});
 
   final String accessToken;

--- a/lib/src/domain/use_cases/authentication_use_case.dart
+++ b/lib/src/domain/use_cases/authentication_use_case.dart
@@ -28,7 +28,7 @@ final class LoginUseCase {
     final request = LoginRequestEntity(
       username: email,
       password: password,
-      shouldRemeber: shouldRemember,
+      shouldRemember: shouldRemember,
     );
 
     return repository.login(request);

--- a/test/data/mappers/login_mapper_test.dart
+++ b/test/data/mappers/login_mapper_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_template/src/data/mappers/login_mapper.dart';
+import 'package:flutter_template/src/data/models/login_model.dart';
+import 'package:flutter_template/src/domain/entities/login_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const mapper = LoginMapper();
+
+  group('LoginMapper', () {
+    test('maps every user field of the response model onto the entity', () {
+      final model = LoginResponseModel(
+        id: 1,
+        username: 'alice',
+        email: 'a@x',
+        firstName: 'A',
+        lastName: 'B',
+        gender: 'female',
+        image: 'https://x/y.png',
+        accessToken: 'a.tok',
+        refreshToken: 'r.tok',
+      );
+
+      final entity = mapper.toEntity(model);
+
+      expect(entity.id, 1);
+      expect(entity.username, 'alice');
+      expect(entity.email, 'a@x');
+      expect(entity.firstName, 'A');
+      expect(entity.lastName, 'B');
+      expect(entity.gender, 'female');
+      expect(entity.image, 'https://x/y.png');
+    });
+
+    test('maps the request entity onto the wire model', () {
+      final entity = LoginRequestEntity(
+        username: 'alice',
+        password: 'pw',
+        shouldRemember: true,
+      );
+
+      final model = mapper.toRequestModel(entity);
+
+      // shouldRemember is client-side state; it never reaches the wire.
+      expect(model.toJson(), {'username': 'alice', 'password': 'pw'});
+    });
+  });
+}

--- a/test/data/mappers/sign_up_mapper_test.dart
+++ b/test/data/mappers/sign_up_mapper_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_template/src/data/mappers/sign_up_mapper.dart';
+import 'package:flutter_template/src/data/models/sign_up_model.dart';
+import 'package:flutter_template/src/domain/entities/sign_up_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const mapper = SignUpMapper();
+
+  group('SignUpMapper', () {
+    test('maps the request entity onto the snake_case wire model', () {
+      final entity = SignUpRequestEntity(
+        firstName: 'A',
+        lastName: 'B',
+        email: 'a@x',
+        password: 'pw',
+      );
+
+      final model = mapper.toRequestModel(entity);
+
+      expect(model.toJson(), {
+        'first_name': 'A',
+        'last_name': 'B',
+        'email': 'a@x',
+        'password': 'pw',
+      });
+    });
+
+    test('maps the response model onto the entity', () {
+      final model = SignUpResponseModel.fromJson({'access_token': 'a.tok'});
+
+      expect(mapper.toEntity(model).accessToken, 'a.tok');
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #56, sibling of #57. Review after those merge, or review only the top commit.

## What this fixes

The sample auth feature violated three rules from the template's own coding standard:

1. **Models extended entities** — all three model classes, coupling wire shapes to domain shapes and letting a model flow anywhere an entity is expected. Models are now standalone `dart_mappable` classes, and a new `data/mappers/` layer (`LoginMapper`, `SignUpMapper`, const-constructible) owns every model ↔ entity conversion.
2. **Empty `interface class` markers** — `LoginEntity {}` and `SignUpEntity {}` were exactly the marker pattern the entity rules forbid. Request/response are now independent classes.
3. **Tokens leaked into the domain** — `LoginResponseEntity` carried `accessToken` while the user's profile smuggled through via inheritance. Inverted: the entity now carries the signed-in user's fields and no tokens. The repository persists tokens through `TokenManager`; they never cross the domain boundary. The mirror rule is pinned by test: `shouldRemember` is client-side state and never reaches the wire.

Also swept up: the sign-up request's `toJson` extension became a real model with snake_case wire keys, and the `shouldRemeber` typo is fixed across entity, use case, and repository.

## Design note

Mappers are const classes, not extensions or mixins — the template's rule (now documented in the guidelines): extensions for one-way, dependency-free transforms like the failure chain; classes for the model ↔ entity seam, where both directions belong in one named, testable unit and formatting may later need injected state. Extension types were evaluated and rejected: they erase at runtime, so the model would leak through casts exactly as inheritance did.

4 new mapper tests (107 total on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved login and sign-up data handling, including complete profile details after login.
  * Sign-up requests now support personal information and correctly formatted field names.
  * “Remember me” preferences are handled consistently and excluded from transmitted credentials.

* **Bug Fixes**
  * Corrected the “Remember me” setting name throughout authentication flows.
  * Improved conversion of authentication responses and requests for more reliable sign-in and registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->